### PR TITLE
More alternative syntax found in the wild and Several paths tested for includes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,15 +7,11 @@
 	<artifactId>mdl</artifactId>
 	<version>0.3</version>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>commons-io</groupId>
-				<artifactId>commons-io</artifactId>
-				<version>2.7</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+	<properties>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 
 	<dependencies>
 
@@ -23,6 +19,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
+			<version>2.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -68,8 +65,5 @@
 
 		</plugins>
 	</build>
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+
 </project>

--- a/src/main/java/cl/MDLConfig.java
+++ b/src/main/java/cl/MDLConfig.java
@@ -3,22 +3,23 @@
  */
 package cl;
 
-import code.CodeBase;
-
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import code.CodeBase;
 import parser.CPUOpParser;
 import parser.CPUOpSpecParser;
-import workers.MDLWorker;
 import parser.CodeBaseParser;
 import parser.ExpressionParser;
 import parser.LineParser;
 import parser.PreProcessor;
 import parser.dialects.ASMSXDialect;
+import parser.dialects.Dialect;
 import parser.dialects.GlassDialect;
 import parser.dialects.SjasmDialect;
-import parser.dialects.Dialect;
+import workers.MDLWorker;
 
 public class MDLConfig {
     // constants:
@@ -47,7 +48,7 @@ public class MDLConfig {
     public int hexStyle = HEX_STYLE_HASH;
     public int dialect = DIALECT_MDL;
     public Dialect dialectParser = null;
-    public List<String> includeDirectories = new ArrayList<>();
+    public List<File> includeDirectories = new ArrayList<>();
 
     public boolean includeBinariesInAnalysis = false;
 
@@ -171,7 +172,12 @@ public class MDLConfig {
                     case "-I":
                         if (args.size()>=2) {
                             args.remove(0);
-                            includeDirectories.add(args.remove(0));
+                            final File includePath = new File(args.remove(0));
+                            if ((includePath.isDirectory())) {
+                                includeDirectories.add(includePath);
+                            } else {
+                                warn("Include path " + includePath + " is not a directory and will be ignored");
+                            }
                         } else {
                             error("Missing path after " + arg);
                             return false;
@@ -276,7 +282,7 @@ public class MDLConfig {
             case DIALECT_SJASM:
                 dialectParser = new SjasmDialect(this);
                 break;
-            
+
         }
 
         return verify();
@@ -294,27 +300,27 @@ public class MDLConfig {
         return true;
     }
 
-    
+
     public void debug(String message) {
         logger.log(MDLLogger.DEBUG, message);
     }
 
-    
+
     public void info(String message) {
         logger.log(MDLLogger.INFO, message);
     }
 
-    
+
     public void warn(String message) {
         logger.log(MDLLogger.WARNING, message);
     }
 
-    
+
     public void error(String message) {
         logger.log(MDLLogger.ERROR, message);
     }
-    
-    
+
+
     public void annotation(String fileName, int lineNumber, String tag, String message) {
         logger.annotation(fileName, lineNumber, tag, message);
     }

--- a/src/main/java/parser/dialects/Dialect.java
+++ b/src/main/java/parser/dialects/Dialect.java
@@ -3,12 +3,12 @@
  */
 package parser.dialects;
 
-import cl.MDLConfig;
+import java.util.List;
+
 import code.CodeBase;
 import code.Expression;
 import code.SourceFile;
 import code.SourceStatement;
-import java.util.List;
 import parser.SourceMacro;
 
 /**
@@ -41,5 +41,5 @@ public interface Dialect {
     // Glass actually compiles the code inside macros, rather than treating it simply as
     // text to be copy/pasted when the macro is expanded (as the default parser of MDL does).
     // - returns "false" if an error occurred
-    public boolean newMacro(SourceMacro macro, CodeBase code);    
+    public boolean newMacro(SourceMacro macro, CodeBase code);
 }

--- a/src/main/resources/data/z80-instruction-set.tsv
+++ b/src/main/resources/data/z80-instruction-set.tsv
@@ -1,1 +1,414 @@
-; Author: Santiago Ontañón Villar (Brain Games)													; Information to construct this table was optained from the following resources:													; - http://map.grauw.nl/resources/z80instr.php (main source; the table in this website, removing the R800 info, is the basis over which I added additional info; check this page for an explanation on the notation)													; - https://wiki.octoate.de/lib/exe/fetch.php/amstradcpc:z80_cpc_timings_cheat_sheet.20131019.pdf (for the Amstrad CPC timings)													; - Zilog Z80 User manual (for the registers, addresses, i/o ports and flags that affect and are affected by an instruction)													; - The Undocumented Z80 Documented (for corrections on the above); Instruction	Timing	Timing MSX	Timing Amstrad CPC	Opcode	Size	Input Registers	Input Flags	Input Ports	Input Memory	Output Registers	Output Flags	Output Ports	Output MemoryADC A,(HL)	7	8	2	8E	1	A,HL	C		HL	A	S,Z,H,P/V,N,C		ADC A,r	4	5	1	88+r	1	A,r	C			A	S,Z,H,P/V,N,C		ADD A,(HL)	7	8	2	86	1	A,HL			HL	A	S,Z,H,P/V,N,C		ADD A,r	4	5	1	80+r	1	A,r				A	S,Z,H,P/V,N,C		ADD HL,BC	11	12	3	9	1	HL,BC				HL	H,N		ADD HL,DE	11	12	3	19	1	HL,DE				HL	H,N		ADD HL,HL	11	12	3	29	1	HL				HL	H,N		ADD HL,SP	11	12	3	39	1	HL,SP				HL	H,N		AND (HL)	7	8	2	A6	1	A,HL			HL	A	S,Z,H,P/V,N,C		AND r	4	5	1	A0+r	1	A,r				A	S,Z,H,P/V,N,C		CCF	4	5	1	3F	1		C				C,N,H		CP (HL)	7	8	2	BE	1	A,HL			HL		S,Z,H,P/V,N,C		CP r	4	5	1	B8+r	1	A,r					S,Z,H,P/V,N,C		CPL	4	5	1	2F	1	A				A	H,N		DAA	4	5	1	27	1	A					S,Z,H,P/V,C		DEC (HL)	11	12	3	35	1	HL			HL		S,Z,H,P/V,N		HLDEC A	4	5	1	3D	1	A				A	S,Z,H,P/V,N		DEC B	4	5	1	5	1	B				B	S,Z,H,P/V,N		DEC BC	6	7	2	0B	1	BC				BC			DEC C	4	5	1	0D	1	C				C	S,Z,H,P/V,N		DEC D	4	5	1	15	1	D				D	S,Z,H,P/V,N		DEC DE	6	7	2	1B	1	DE				DE			DEC E	4	5	1	1D	1	E				E	S,Z,H,P/V,N		DEC H	4	5	1	25	1	H				H	S,Z,H,P/V,N		DEC HL	6	7	2	2B	1	HL				HL			DEC L	4	5	1	2D	1	L				L	S,Z,H,P/V,N		DEC SP	6	7	2	3B	1	SP				SP			DI	4	5	1	F3	1								EI	4	5	1	FB	1								EX (SP),HL	19	20	6	E3	1	HL,SP			[SP:SP+1]	HL			[SP:SP+1]EX AF,AF'	4	5	1	8	1	AF				AF			EX DE,HL	4	5	1	EB	1	DE,HL				DE,HL			EXX	4	5	1	D9	1	BC,DE,HL				BC,DE,HL			HALT	4	5	1	76	1								INC (HL)	11	12	3	34	1	HL			HL		S,Z,H,P/V,N		HLINC A	4	5	1	3C	1	A				A	S,Z,H,P/V,N		INC B	4	5	1	4	1	B				B	S,Z,H,P/V,N		INC BC	6	7	2	3	1	BC				BC			INC C	4	5	1	0C	1	C				C	S,Z,H,P/V,N		INC D	4	5	1	14	1	D				D	S,Z,H,P/V,N		INC DE	6	7	2	13	1	DE				DE			INC E	4	5	1	1C	1	B				B	S,Z,H,P/V,N		INC H	4	5	1	24	1	H				H	S,Z,H,P/V,N		INC HL	6	7	2	23	1	HL				HL			INC L	4	5	1	2C	1	L				L	S,Z,H,P/V,N		INC SP	6	7	2	33	1	SP				SP			JP HL	4	5	1	E9	1	HL				PC			JP (HL)	4	5	1	E9	1	HL				PC			LD (BC),A	7	8	2	2	1	A,BC							BCLD (DE),A	7	8	2	12	1	A,DE							DELD (HL),r	7	8	2	70+r	1	r,HL							HLLD A,(BC)	7	8	2	0A	1	BC			BC	A			LD A,(DE)	7	8	2	1A	1	DE			DE	A			LD A,(HL)	7	8	2	7E	1	HL			HL	A			LD A,r	4	5	1	78+r	1	r				A			LD B,(HL)	7	8	2	46	1	HL			HL	B			LD B,r	4	5	1	40+r	1	r				B			LD C,(HL)	7	8	2	4E	1	HL			HL	C			LD C,r	4	5	1	48+r	1	r				C			LD D,(HL)	7	8	2	56	1	HL			HL	D			LD D,r	4	5	1	50+r	1	r				D			LD E,(HL)	7	8	2	5E	1	HL			HL	E			LD E,r	4	5	1	58+r	1	r				E			LD H,(HL)	7	8	2	66	1	HL			HL	H			LD H,r	4	5	1	60+r	1	r				H			LD L,(HL)	7	8	2	6E	1	HL			HL	L			LD L,r	4	5	1	68+r	1	r				L			LD SP,HL	6	7	2	F9	1	HL				SP			NOP	4	5	1	0	1								OR (HL)	7	8	2	B6	1	A,HL			HL	A	S,Z,H,P/V,N,C		OR r	4	5	1	B0+r	1	A,r				A	S,Z,H,P/V,N,C		POP AF	10	11	3	F1	1	SP			[SP:SP+1]	AF,SP			POP BC	10	11	3	C1	1	SP			[SP:SP+1]	BC,SP			POP DE	10	11	3	D1	1	SP			[SP:SP+1]	DE,SP			POP HL	10	11	3	E1	1	SP			[SP:SP+1]	HL,SP			PUSH AF	11	12	4	F5	1	AF,SP				SP			[SP-2:SP-1]PUSH BC	11	12	4	C5	1	BC,SP				SP			[SP-2:SP-1]PUSH DE	11	12	4	D5	1	DE,SP				SP			[SP-2:SP-1]PUSH HL	11	12	4	E5	1	HL,SP				SP			[SP-2:SP-1]RET	10	11	3	C9	1	SP			[SP:SP+1]	SP,PC			RET C	5/11	6/12	2/4	D8	1	SP	C		[SP:SP+1]	SP,PC			RET M	5/11	6/12	2/4	F8	1	SP	S		[SP:SP+1]	SP,PC			RET NC	5/11	6/12	2/4	D0	1	SP	C		[SP:SP+1]	SP,PC			RET NZ	5/11	6/12	2/4	C0	1	SP	Z		[SP:SP+1]	SP,PC			RET P	5/11	6/12	2/4	F0	1	SP	S		[SP:SP+1]	SP,PC			RET PE	5/11	6/12	2/4	E8	1	SP	P		[SP:SP+1]	SP,PC			RET PO	5/11	6/12	2/4	E0	1	SP	P		[SP:SP+1]	SP,PC			RET Z	5/11	6/12	2/4	C8	1	SP	Z		[SP:SP+1]	SP,PC			RLA	4	5	1	17	1	A	C			A	H,N,C		RLCA	4	5	1	7	1	A				A	H,N,C		RRA	4	5	1	1F	1	A	C			A	H,N,C		RRCA	4	5	1	0F	1	A				A	H,N,C		RST 0	11	12	4	C7	1	SP				SP,PC			[SP-2:SP-1]RST 10H	11	12	4	D7	1	SP				SP,PC			[SP-2:SP-1]RST 18H	11	12	4	DF	1	SP				SP,PC			[SP-2:SP-1]RST 20H	11	12	4	E7	1	SP				SP,PC			[SP-2:SP-1]RST 28H	11	12	4	EF	1	SP				SP,PC			[SP-2:SP-1]RST 30H	11	12	4	F7	1	SP				SP,PC			[SP-2:SP-1]RST 38H	11	12	4	FF	1	SP				SP,PC			[SP-2:SP-1]RST 8H	11	12	4	CF	1	SP				SP,PC			[SP-2:SP-1]SBC A,(HL)	7	8	2	9E	1	A,HL	C		HL	A	S,Z,H,P/V,N,C		SBC A,A	4	5	1	98+r	1		C			A	S,Z,H,P/V,N,C		SBC A,B	4	5	1	98+r	1	A,B	C			A	S,Z,H,P/V,N,C		SBC A,C	4	5	1	98+r	1	A,C	C			A	S,Z,H,P/V,N,C		SBC A,D	4	5	1	98+r	1	A,D	C			A	S,Z,H,P/V,N,C		SBC A,E	4	5	1	98+r	1	A,E	C			A	S,Z,H,P/V,N,C		SBC A,H	4	5	1	98+r	1	A,H	C			A	S,Z,H,P/V,N,C		SBC A,L	4	5	1	98+r	1	A,L	C			A	S,Z,H,P/V,N,C		SCF	4	5	1	37	1						H,N,C		SUB (HL)	7	8	2	96	1	A,HL			HL	A	S,Z,H,P/V,N,C		SUB A	4	5	1	90+r	1					A	S,Z,H,P/V,N,C		SUB B	4	5	1	90+r	1	A,B				A	S,Z,H,P/V,N,C		SUB C	4	5	1	90+r	1	A,C				A	S,Z,H,P/V,N,C		SUB D	4	5	1	90+r	1	A,D				A	S,Z,H,P/V,N,C		SUB E	4	5	1	90+r	1	A,E				A	S,Z,H,P/V,N,C		SUB H	4	5	1	90+r	1	A,H				A	S,Z,H,P/V,N,C		SUB L	4	5	1	90+r	1	A,L				A	S,Z,H,P/V,N,C		XOR (HL)	7	8	2	AE	1	A,HL			HL	A	S,Z,H,P/V,N,C		XOR A	4	5	1	A8+7	1					A	S,Z,H,P/V,N,C		XOR B	4	5	1	A8+0	1	A,B				A	S,Z,H,P/V,N,C		XOR C	4	5	1	A8+1	1	A,C				A	S,Z,H,P/V,N,C		XOR D	4	5	1	A8+2	1	A,D				A	S,Z,H,P/V,N,C		XOR E	4	5	1	A8+3	1	A,E				A	S,Z,H,P/V,N,C		XOR H	4	5	1	A8+4	1	A,H				A	S,Z,H,P/V,N,C		XOR L	4	5	1	A8+5	1	A,L				A	S,Z,H,P/V,N,C		ADC A,IXp	8	10	2	DD 88+p	2	A,IXp	C			A	S,Z,H,P/V,N,C		ADC A,IYq	8	10	2	FD 88+q	2	A,IYq	C			A	S,Z,H,P/V,N,C		ADC A,n	7	8	2	CE n	2	A	C			A	S,Z,H,P/V,N,C		ADC HL,BC	15	17	4	ED 4A	2	HL,BC	C			HL	S,Z,H,P/V,N,C		ADC HL,DE	15	17	4	ED 5A	2	HL,DE	C			HL	S,Z,H,P/V,N,C		ADC HL,HL	15	17	4	ED 6A	2	HL	C			HL	S,Z,H,P/V,N,C		ADC HL,SP	15	17	4	ED 7A	2	HL,SP	C			HL	S,Z,H,P/V,N,C		ADD A,IXp	8	10	2	DD 80+p	2	A,IXp				A	S,Z,H,P/V,N,C		ADD A,IYq	8	10	2	FD 80+q	2	A,IYq				A	S,Z,H,P/V,N,C		ADD A,n	7	8	2	C6 n	2	A				A	S,Z,H,P/V,N,C		ADD IX,BC	15	17	4	DD 09	2	IX,BC				IX	H,N,C		ADD IX,DE	15	17	4	DD 19	2	IX,DE				IX	H,N,C		ADD IX,IX	15	17	4	DD 29	2	IX				IX	H,N,C		ADD IX,SP	15	17	4	DD 39	2	IX,SP				IX	H,N,C		ADD IY,BC	15	17	4	FD 09	2	IY,BC				IY	H,N,C		ADD IY,DE	15	17	4	FD 19	2	IY,DE				IY	H,N,C		ADD IY,IY	15	17	4	FD 29	2	IY				IY	H,N,C		ADD IY,SP	15	17	4	FD 39	2	IY,SP				IY	H,N,C		AND IXp	8	10	2	DD A0+p	2	A,IXp				A	S,Z,H,P/V,N,C		AND IYq	8	10	2	FD A0+q	2	A,IYq				A	S,Z,H,P/V,N,C		AND n	7	8	2	E6 n	2	A				A	S,Z,H,P/V,N,C		BIT b,(HL)	12	14	3	CB 46+8*b	2	HL			HL		S,Z,H,P/V,N		BIT b,r	8	10	2	CB 40+8*b+r	2	r					S,Z,H,P/V,N		CP IXp	8	10	2	DD B8+p	2	A,IXp					S,Z,H,P/V,N,C		CP IYq	8	10	2	FD B8+q	2	A,IYq					S,Z,H,P/V,N,C		CP n	7	8	2	FE n	2	A					S,Z,H,P/V,N,C		CPD	16	18	5	ED A9	2	A,HL,BC			HL	HL,BC	S,Z,H,P/V,N		CPDR	21/16	23/18	6/5	ED B9	2	A,HL,BC			[HL-B:HL]	HL,BC	S,Z,H,P/V,N		CPI	16	18	5	ED A1	2	A,HL,BC			HL	HL,BC	S,Z,H,P/V,N		CPIR	21/16	23/18	6/5	ED B1	2	A,HL,BC			[HL:HL+B]	HL,BC	S,Z,H,P/V,N		DEC IX	10	12	3	DD 2B	2	IX				IX			DEC IXp	8	10	2	DD 05+8*p	2	IXp				IXp	S,Z,H,P/V,N		DEC IY	10	12	3	FD 2B	2	IY				IY			DEC IYq	8	10	2	FD 05+8*q	2	IYq				IYq	S,Z,H,P/V,N		DJNZ o	13/8	14/9	4/3	10 o	2	B				B,PC			EX (SP),IX	23	25	7	DD E3	2	HL,IX			[SP:SP+1]	IX			[SP:SP+1]EX (SP),IY	23	25	7	FD E3	2	HL,IY			[SP:SP+1]	IY			[SP:SP+1]IM 0	8	10	2	ED 46	2								IM 1	8	10	2	ED 56	2								IM 2	8	10	2	ED 5E	2								IN A,(C)	12	14	4	ED 78	2			C		A	S,Z,N		IN A,(n)	11	12	3	DB n	2			n		A	S,Z,N		IN B,(C)	12	14	4	ED 40	2			C		B	S,Z,N		IN C,(C)	12	14	4	ED 48	2			C		C	S,Z,N		IN D,(C)	12	14	4	ED 50	2			C		D	S,Z,N		IN E,(C)	12	14	4	ED 58	2			C		E	S,Z,N		IN F,(C)	12	14	4	ED 70	2			C		F	S,Z,N		IN H,(C)	12	14	4	ED 60	2			C		H	S,Z,N		IN L,(C)	12	14	4	ED 68	2			C		L	S,Z,N		INC IX	10	12	3	DD 23	2	IX				IX			INC IXp	8	10	2	DD 04+8*p	2	IXp				IXp	S,Z,H,P/V,N		INC IY	10	12	3	FD 23	2	IY				IY			INC IYq	8	10	2	FD 04+8*q	2	IYq				IYq	S,Z,H,P/V,N		IND	16	18	5	ED AA	2	HL,B,C		C		HL,B	S,Z,H,P/V,N,C		HLINDR	21/16	23/18	6/5	ED BA	2	HL,B,C		C		HL,B	S,Z,H,P/V,N,C		[HL-B:HL]INI	16	18	5	ED A2	2	HL,B,C		C		HL,B	S,Z,H,P/V,N,C		HLINIR	21/16	23/18	6/5	ED B2	2	HL,B,C		C		HL,B	S,Z,H,P/V,N,C		[HL:HL+B]JP IX	8	10	2	DD E9	2	IX				PC			JP (IX)	8	10	2	DD E9	2	IX				PC			JP IY	8	10	2	FD E9	2	IY				PC			JP (IY)	8	10	2	FD E9	2	IY				PC			JR C,o	7/12	13/8	3/2	38 o	2		C			PC			JR NC,o	7/12	13/8	3/2	30 o	2		C			PC			JR NZ,o	7/12	13/8	3/2	20 o	2		Z			PC			JR Z,o	7/12	13/8	3/2	28 o	2		Z			PC			JR o	12	13	3	18 o	2					PC			LD (HL),n	10	11	3	36 n	2	HL							HLLD A,I	9	11	3	ED 57	2	I				A			LD A,IXp	8	10	2	DD 78+p	2	IXp				A			LD A,IYq	8	10	2	FD 78+q	2	IYq				A			LD A,R	9	11	3	ED 5F	2	R				A			LD A,n	7	8	2	3E n	2					A			LD B,IXp	8	10	2	DD 40+p	2	IXp				B			LD B,IYq	8	10	2	FD 40+q	2	IYq				B			LD B,n	7	8	2	06 n	2					B			LD C,IXp	8	10	2	DD 48+p	2	IXp				C			LD C,IYq	8	10	2	FD 48+q	2	IYq				C			LD C,n	7	8	2	0E n	2					C			LD D,IXp	8	10	2	DD 50+p	2	IXp				D			LD D,IYq	8	10	2	FD 50+q	2	IYq				D			LD D,n	7	8	2	16 n	2					D			LD E,IXp	8	10	2	DD 58+p	2	IXp				E			LD E,IYq	8	10	2	FD 58+q	2	IYq				E			LD E,n	7	8	2	1E n	2					E			LD H,n	7	8	2	26 n	2					H			LD I,A	9	11	3	ED 47	2	A				I			LD IXh,p	8	10	3	DD 60+p	2	p				IXh			LD IXl,p	8	10	3	DD 68+p	2	p				IXl			LD IYh,q	8	10	3	FD 60+q	2	q				IYh			LD IYl,q	8	10	3	FD 68+q	2	q				IYl			LD L,n	7	8	2	2E n	2					L			LD R,A	9	11	3	ED 4F	2	A				R			LD SP,IX	10	12	3	DD F9	2	IX				SP			LD SP,IY	10	12	3	FD F9	2	IY				SP			LDD	16	18	5	ED A8	2	BC,DE,HL			HL	BC,HL	H,P/V,N		DELDDR	21/16	23/18	6/5	ED B8	2	BC,DE,HL			[HL-BC:HL]	BC,DE,HL			[DE-BC:DE]LDI	16	18	5	ED A0	2	BC,DE,HL			HL	BC,HL	H,P/V,N		DELDIR	21/16	23/18	6/5	ED B0	2	BC,DE,HL			[HL:HL+BC]	BC,DE,HL			[DE:DE+BC]NEG	8	10	2	ED 44	2	A				A	S,Z,H,P/V,N,C		OR IXp	8	10	2	DD B0+p	2	A,IXp				A	S,Z,H,P/V,N,C		OR IYq	8	10	2	FD B0+q	2	A,IYq				A	S,Z,H,P/V,N,C		OR n	7	8	2	F6 n	2	A				A	S,Z,H,P/V,N,C		OTDR	21/16	23/18	6/5	ED BB	2	B,C,HL			[HL-B:HL]	B,HL	S,Z,H,P/V,N,C	C	OTIR	21/16	23/18	6/5	ED B3	2	B,C,HL			[HL:HL+B]	B,HL	S,Z,H,P/V,N,C	C	OUT (C),A	12	14	4	ED 79	2	A,C					S,Z,N	C	OUT (C),B	12	14	4	ED 41	2	B,C					S,Z,N	C	OUT (C),C	12	14	4	ED 49	2	C					S,Z,N	C	OUT (C),D	12	14	4	ED 51	2	C,D					S,Z,N	C	OUT (C),E	12	14	4	ED 59	2	C,E					S,Z,N	C	OUT (C),H	12	14	4	ED 61	2	C,H					S,Z,N	C	OUT (C),L	12	14	4	ED 69	2	C,L					S,Z,N	C	OUT (n),A	11	12	4	D3 n	2	A					S,Z,N	n	OUTD	16	18	5	ED AB	2	B,C,HL			HL	B,HL	S,Z,H,P/V,N,C	C	OUTI	16	18	5	ED A3	2	B,C,HL			HL	B,HL	S,Z,H,P/V,N,C	C	POP IX	14	16	5	DD E1	2				[SP:SP+1]	IX,SP			POP IY	14	16	5	FD E1	2				[SP:SP+1]	IY,SP			PUSH IX	15	17	5	DD E5	2	IX				SP			[SP-2:SP-1]PUSH IY	15	17	5	FD E5	2	IY				SP			[SP-2:SP-1]RES b,(HL)	15	17	4	CB 86+8*b	2	HL			HL				HLRES b,r	8	10	2	CB 80+8*b+r	2	r				r			RETI	14	16	4	ED 4D	2				[SP:SP+1]	SP,PC			RETN	14	16	4	ED 45	2				[SP:SP+1]	SP,PC			RL (HL)	15	17	4	CB 16	2	HL	C			HL	S,Z,H,P/V,N,C		HLRL r	8	10	2	CB 10+r	2	r	C				S,Z,H,P/V,N,C		RLC (HL)	15	17	4	CB 06	2	HL				HL	S,Z,H,P/V,N,C		HLRLC r	8	10	2	CB 00+r	2	r					S,Z,H,P/V,N,C		RLD	18	20	5	ED 6F	2	A					S,Z,H,P/V,N		RR (HL)	15	17	4	CB 1E	2	HL	C			HL	S,Z,H,P/V,N,C		HLRR r	8	10	2	CB 18+r	2	r	C				S,Z,H,P/V,N,C		RRC (HL)	15	17	4	CB 0E	2	HL				HL	S,Z,H,P/V,N,C		HLRRC r	8	10	2	CB 08+r	2	r					S,Z,H,P/V,N,C		RRD	18	20	5	ED 67	2	A					S,Z,H,P/V,N		SBC A,IXp	8	10	2	DD 98+p	2	A,IXp	C			A	S,Z,H,P/V,N,C		SBC A,IYq	8	10	2	FD 98+q	2	A,IYq	C			A	S,Z,H,P/V,N,C		SBC A,n	7	8	2	DE n	2	A	C			A	S,Z,H,P/V,N,C		SBC HL,BC	15	17	4	ED 42	2	HL,BC	C			HL	S,Z,H,P/V,N,C		SBC HL,DE	15	17	4	ED 52	2	HL,DE	C			HL	S,Z,H,P/V,N,C		SBC HL,HL	15	17	4	ED 62	2	HL	C			HL	S,Z,H,P/V,N,C		SBC HL,SP	15	17	4	ED 72	2	HL,SP	C			HL	S,Z,H,P/V,N,C		SET b,(HL)	15	17	4	CB C6+8*b	2	HL			HL				HLSET b,r	8	10	2	CB C0+8*b+r	2	r				r			SLA (HL)	15	17	4	CB 26	2	HL			HL		S,Z,H,P/V,N,C		HLSLA r	8	10	2	CB 20+r	2	r				r	S,Z,H,P/V,N,C		SRA (HL)	15	17	4	CB 2E	2	HL			HL		S,Z,H,P/V,N,C		HLSRA r	8	10	2	CB 28+r	2	r				r	S,Z,H,P/V,N,C		SRL (HL)	15	17	4	CB 3E	2	HL			HL		S,Z,H,P/V,N,C		HLSRL r	8	10	2	CB 38+r	2	r				r	S,Z,H,P/V,N,C		SUB IXp	8	10	2	DD 90+p	2	A,IXp				A	S,Z,H,P/V,N,C		SUB IYq	8	10	2	FD 90+q	2	A,IYq				A	S,Z,H,P/V,N,C		SUB n	7	8	2	D6 n	2	A				A	S,Z,H,P/V,N,C		XOR IXp	8	10	2	DD A8+p	2	A,IXp				A	S,Z,H,P/V,N,C		XOR IYq	8	10	2	FD A8+q	2	A,IYq				A	S,Z,H,P/V,N,C		XOR n	7	8	2	EE n	2	A				A	S,Z,H,P/V,N,C		ADC A,(IX+o)	19	21	5	DD 8E o	3	A,IX	C		IX+o	A	S,Z,H,P/V,N,C		ADC A,(IY+o)	19	21	5	FD 8E o	3	A,IY	C		IY+o	A	S,Z,H,P/V,N,C		ADD A,(IX+o)	19	21	5	DD 86 o	3	A,IX			IX+o	A	S,Z,H,P/V,N,C		ADD A,(IY+o)	19	21	5	FD 86 o	3	A,IY			IY+o	A	S,Z,H,P/V,N,C		AND (IX+o)	19	21	5	DD A6 o	3	A,IX			IX+o	A	S,Z,H,P/V,N,C		AND (IY+o)	19	21	5	FD A6 o	3	A,IY			IY+o	A	S,Z,H,P/V,N,C		CALL C,nn	17/10	18/11	5/3	DC nn nn	3	SP	C			SP,PC			[SP-2:SP-1]CALL M,nn	17/10	18/11	5/3	FC nn nn	3	SP	S			SP,PC			[SP-2:SP-1]CALL NC,nn	17/10	18/11	5/3	D4 nn nn	3	SP	C			SP,PC			[SP-2:SP-1]CALL NZ,nn	17/10	18/11	5/3	C4 nn nn	3	SP	Z			SP,PC			[SP-2:SP-1]CALL P,nn	17/10	18/11	5/3	F4 nn nn	3	SP	S			SP,PC			[SP-2:SP-1]CALL PE,nn	17/10	18/11	5/3	EC nn nn	3	SP	P/V			SP,PC			[SP-2:SP-1]CALL PO,nn	17/10	18/11	5/3	E4 nn nn	3	SP	P/V			SP,PC			[SP-2:SP-1]CALL Z,nn	17/10	18/11	5/3	CC nn nn	3	SP	Z			SP,PC			[SP-2:SP-1]CALL nn	17	18	5	CD nn nn	3	SP				SP,PC			[SP-2:SP-1]CP (IX+o)	19	21	5	DD BE o	3	A,IX			IX+o		S,Z,H,P/V,N,C		CP (IY+o)	19	21	5	FD BE o	3	A,IY			IY+o		S,Z,H,P/V,N,C		DEC (IX+o)	23	25	6	DD 35 o	3	IX			IX+o		S,Z,H,P/V,N		IX+oDEC (IY+o)	23	25	6	FD 35 o	3	IY			IY+o		S,Z,H,P/V,N		IY+oINC (IX+o)	23	25	6	DD 34 o	3	IX			IX+o		S,Z,H,P/V,N		IX+oINC (IY+o)	23	25	6	FD 34 o	3	IY			IY+o		S,Z,H,P/V,N		IY+oJP C,nn	10	11	3	DA nn nn	3		C			PC			JP M,nn	10	11	3	FA nn nn	3		S			PC			JP NC,nn	10	11	3	D2 nn nn	3		C			PC			JP NZ,nn	10	11	3	C2 nn nn	3		Z			PC			JP P,nn	10	11	3	F2 nn nn	3		S			PC			JP PE,nn	10	11	3	EA nn nn	3		P/V			PC			JP PO,nn	10	11	3	E2 nn nn	3		P/V			PC			JP Z,nn	10	11	3	CA nn nn	3		Z			PC			JP nn	10	11	3	C3 nn nn	3					PC			LD (IX+o),r	19	21	5	DD 70+r o	3	IX,r							IX+oLD (IY+o),r	19	21	5	FD 70+r o	3	IY,r							IY+oLD (nn),A	13	14	4	32 nn nn	3	A							nnLD (nn),HL	16	17	5	22 nn nn	3	HL							[nn:nn+1]LD A,(IX+o)	19	21	5	DD 7E o	3	IX			IX+o	A			LD A,(IY+o)	19	21	5	FD 7E o	3	IY			IY+o	A			LD A,(nn)	13	14	4	3A nn nn	3				nn	A			LD B,(IX+o)	19	21	5	DD 46 o	3	IX			IX+o	B			LD B,(IY+o)	19	21	5	FD 46 o	3	IY			IY+o	B			LD BC,nn	10	11	3	01 nn nn	3					BC			LD C,(IX+o)	19	21	5	DD 4E o	3	IX			IX+o	C			LD C,(IY+o)	19	21	5	FD 4E o	3	IY			IY+o	C			LD D,(IX+o)	19	21	5	DD 56 o	3	IX			IX+o	D			LD D,(IY+o)	19	21	5	FD 56 o	3	IY			IY+o	D			LD DE,nn	10	11	3	11 nn nn	3					DE			LD E,(IX+o)	19	21	5	DD 5E o	3	IX			IX+o	E			LD E,(IY+o)	19	21	5	FD 5E o	3	IY			IY+o	E			LD H,(IX+o)	19	21	5	DD 66 o	3	IX			IX+o	H			LD H,(IY+o)	19	21	5	FD 66 o	3	IY			IY+o	H			LD HL,(nn)	16	17	5	2A nn nn	3				[nn:nn+1]	HL			LD HL,nn	10	11	3	21 nn nn	3					HL			LD IXh,n	11	13	3	DD 26 n	3					IXh			LD IXl,n	11	13	3	DD 2E n	3					IXl			LD IYh,n	11	13	3	FD 26 n	3					IYh			LD IYl,n	11	13	3	FD 2E n	3					IYl			LD L,(IX+o)	19	21	5	DD 6E o	3	IX			IX+o	L			LD L,(IY+o)	19	21	5	FD 6E o	3	IY			IY+o	L			LD SP,nn	10	11	3	31 nn nn	3					SP			OR (IX+o)	19	21	5	DD B6 o	3	A,IX			IX+o	A	S,Z,H,P/V,N,C		OR (IY+o)	19	21	5	FD B6 o	3	A,IY			IY+o	A	S,Z,H,P/V,N,C		SBC A,(IX+o)	19	21	5	DD 9E o	3	A,IX	C		IX+o	A	S,Z,H,P/V,N,C		SBC A,(IY+o)	19	21	5	FD 9E o	3	A,IY	C		IY+o	A	S,Z,H,P/V,N,C		SUB (IX+o)	19	21	5	DD 96 o	3	A,IX			IX+o	A	S,Z,H,P/V,N,C		SUB (IY+o)	19	21	5	FD 96 o	3	A,IY			IY+o	A	S,Z,H,P/V,N,C		XOR (IX+o)	19	21	5	DD AE o	3	A,IX			IX+o	A	S,Z,H,P/V,N,C		XOR (IY+o)	19	21	5	FD AE o	3	A,IY			IY+o	A	S,Z,H,P/V,N,C		BIT b,(IX+o)	20	22	6	DD CB o 46+8*b	4	IX			IX+o		S,Z,H,P/V,N		BIT b,(IY+o)	20	22	6	FD CB o 46+8*b	4	IY			IY+o		S,Z,H,P/V,N		LD (IX+o),n	19	21	6	DD 36 o n	4	IX							IX+oLD (IY+o),n	19	21	6	FD 36 o n	4	IY							IY+oLD (nn),BC	20	22	6	ED 43 nn nn	4	BC							[nn:nn+1]LD (nn),DE	20	22	6	ED 53 nn nn	4	DE							[nn:nn+1]LD (nn),IX	20	22	6	DD 22 nn nn	4	IX							[nn:nn+1]LD (nn),IY	20	22	6	FD 22 nn nn	4	IY							[nn:nn+1]LD (nn),SP	20	22	6	ED 73 nn nn	4	SP							[nn:nn+1]LD BC,(nn)	20	22	6	ED 4B nn nn	4				[nn:nn+1]	BC			LD DE,(nn)	20	22	6	ED 5B nn nn	4				[nn:nn+1]	DE			LD IX,(nn)	20	22	6	DD 2A nn nn	4				[nn:nn+1]	IX			LD IX,nn	14	16	4	DD 21 nn nn	4					IX			LD IY,(nn)	20	22	6	FD 2A nn nn	4				[nn:nn+1]	IY			LD IY,nn	14	16	4	FD 21 nn nn	4					IY			LD SP,(nn)	20	22	6	ED 7B nn nn	4				[nn:nn+1]	SP			RES b,(IX+o)	23	25	7	DD CB o 86+8*b	4	IX			IX+o				IX+oRES b,(IY+o)	23	25	7	FD CB o 86+8*b	4	IY			IY+o				IY+oRL (IX+o)	23	25	7	DD CB o 16	4	IX	C		IX+o		S,Z,H,P/V,N,C		IX+oRL (IY+o)	23	25	7	FD CB o 16	4	IY	C		IY+o		S,Z,H,P/V,N,C		IY+oRLC (IX+o)	23	25	7	DD CB o 06	4	IX			IX+o		S,Z,H,P/V,N,C		IX+oRLC (IY+o)	23	25	7	FD CB o 06	4	IY			IY+o		S,Z,H,P/V,N,C		IY+oRR (IX+o)	23	25	7	DD CB o 1E	4	IX	C		IX+o		S,Z,H,P/V,N,C		IX+oRR (IY+o)	23	25	7	FD CB o 1E	4	IY	C		IY+o		S,Z,H,P/V,N,C		IY+oRRC (IX+o)	23	25	7	DD CB o 0E	4	IX			IX+o		S,Z,H,P/V,N,C		IX+oRRC (IY+o)	23	25	7	FD CB o 0E	4	IY			IY+o		S,Z,H,P/V,N,C		IY+oSET b,(IX+o)	23	25	7	DD CB o C6+8*b	4	IX			IX+o				IX+oSET b,(IY+o)	23	25	7	FD CB o C6+8*b	4	IY			IY+o				IY+oSLA (IX+o)	23	25	7	DD CB o 26	4	IX			IX+o		S,Z,H,P/V,N,C		IX+oSLA (IY+o)	23	25	7	FD CB o 26	4	IY			IY+o		S,Z,H,P/V,N,C		IY+oSRA (IX+o)	23	25	7	DD CB o 2E	4	IX			IX+o		S,Z,H,P/V,N,C		IX+oSRA (IY+o)	23	25	7	FD CB o 2E	4	IY			IY+o		S,Z,H,P/V,N,C		IY+oSRL (IX+o)	23	25	7	DD CB o 3E	4	IX			IX+o		S,Z,H,P/V,N,C		IX+oSRL (IY+o)	23	25	7	FD CB o 3E	4	IY			IY+o		S,Z,H,P/V,N,C		IY+o; Unofficial alternative way to write some instructions that some assemblers support:ADC (HL)	7	8	2	8E	1	A,HL	C		HL	A	S,Z,H,P/V,N,C		ADC r	4	5	1	88+r	1	A,r	C			A	S,Z,H,P/V,N,C		ADC n	7	8	2	CE n	2	A	C			A	S,Z,H,P/V,N,C		ADD r	4	5	1	80+r	1	A,r				A	S,Z,H,P/V,N,C		ADD (HL)	7	8	2	86	1	A,HL			HL	A	S,Z,H,P/V,N,C		ADD n	7	8	2	C6 n	2	A				A	S,Z,H,P/V,N,C		SBC (HL)	7	8	2	9E	1	A,HL	C		HL	A	S,Z,H,P/V,N,C		SBC A	4	5	1	98+r	1		C			A	S,Z,H,P/V,N,C		SBC B	4	5	1	98+r	1	A,B	C			A	S,Z,H,P/V,N,C		SBC C	4	5	1	98+r	1	A,C	C			A	S,Z,H,P/V,N,C		SBC D	4	5	1	98+r	1	A,D	C			A	S,Z,H,P/V,N,C		SBC E	4	5	1	98+r	1	A,E	C			A	S,Z,H,P/V,N,C		SBC H	4	5	1	98+r	1	A,H	C			A	S,Z,H,P/V,N,C		SBC L	4	5	1	98+r	1	A,L	C			A	S,Z,H,P/V,N,C		
+; Author: Santiago Ontañón Villar (Brain Games)
+; Information to construct this table was optained from the following resources:
+; - http://map.grauw.nl/resources/z80instr.php (main source; the table in this website, removing the R800 info, is the basis over which I added additional info; check this page for an explanation on the notation)
+; - https://wiki.octoate.de/lib/exe/fetch.php/amstradcpc:z80_cpc_timings_cheat_sheet.20131019.pdf (for the Amstrad CPC timings)
+; - Zilog Z80 User manual (for the registers, addresses, i/o ports and flags that affect and are affected by an instruction)
+; - The Undocumented Z80 Documented (for corrections on the above)
+; Instruction	Timing	Timing MSX	Timing Amstrad CPC	Opcode	Size	Input Registers	Input Flags	Input Ports	Input Memory	Output Registers	Output Flags	Output Ports	Output Memory
+ADC A,(HL)	7	8	2	8E	1	A,HL	C		HL	A	S,Z,H,P/V,N,C
+ADC A,r	4	5	1	88+r	1	A,r	C			A	S,Z,H,P/V,N,C
+ADD A,(HL)	7	8	2	86	1	A,HL			HL	A	S,Z,H,P/V,N,C
+ADD A,r	4	5	1	80+r	1	A,r				A	S,Z,H,P/V,N,C
+ADD HL,BC	11	12	3	9	1	HL,BC				HL	H,N
+ADD HL,DE	11	12	3	19	1	HL,DE				HL	H,N
+ADD HL,HL	11	12	3	29	1	HL				HL	H,N
+ADD HL,SP	11	12	3	39	1	HL,SP				HL	H,N
+AND (HL)	7	8	2	A6	1	A,HL			HL	A	S,Z,H,P/V,N,C
+AND r	4	5	1	A0+r	1	A,r				A	S,Z,H,P/V,N,C
+CCF	4	5	1	3F	1		C				C,N,H
+CP (HL)	7	8	2	BE	1	A,HL			HL		S,Z,H,P/V,N,C
+CP r	4	5	1	B8+r	1	A,r					S,Z,H,P/V,N,C
+CPL	4	5	1	2F	1	A				A	H,N
+DAA	4	5	1	27	1	A					S,Z,H,P/V,C
+DEC (HL)	11	12	3	35	1	HL			HL		S,Z,H,P/V,N		HL
+DEC A	4	5	1	3D	1	A				A	S,Z,H,P/V,N
+DEC B	4	5	1	5	1	B				B	S,Z,H,P/V,N
+DEC BC	6	7	2	0B	1	BC				BC
+DEC C	4	5	1	0D	1	C				C	S,Z,H,P/V,N
+DEC D	4	5	1	15	1	D				D	S,Z,H,P/V,N
+DEC DE	6	7	2	1B	1	DE				DE
+DEC E	4	5	1	1D	1	E				E	S,Z,H,P/V,N
+DEC H	4	5	1	25	1	H				H	S,Z,H,P/V,N
+DEC HL	6	7	2	2B	1	HL				HL
+DEC L	4	5	1	2D	1	L				L	S,Z,H,P/V,N
+DEC SP	6	7	2	3B	1	SP				SP
+DI	4	5	1	F3	1
+EI	4	5	1	FB	1
+EX (SP),HL	19	20	6	E3	1	HL,SP			[SP:SP+1]	HL			[SP:SP+1]
+EX AF,AF'	4	5	1	8	1	AF				AF
+EX DE,HL	4	5	1	EB	1	DE,HL				DE,HL
+EXX	4	5	1	D9	1	BC,DE,HL				BC,DE,HL
+HALT	4	5	1	76	1
+INC (HL)	11	12	3	34	1	HL			HL		S,Z,H,P/V,N		HL
+INC A	4	5	1	3C	1	A				A	S,Z,H,P/V,N
+INC B	4	5	1	4	1	B				B	S,Z,H,P/V,N
+INC BC	6	7	2	3	1	BC				BC
+INC C	4	5	1	0C	1	C				C	S,Z,H,P/V,N
+INC D	4	5	1	14	1	D				D	S,Z,H,P/V,N
+INC DE	6	7	2	13	1	DE				DE
+INC E	4	5	1	1C	1	B				B	S,Z,H,P/V,N
+INC H	4	5	1	24	1	H				H	S,Z,H,P/V,N
+INC HL	6	7	2	23	1	HL				HL
+INC L	4	5	1	2C	1	L				L	S,Z,H,P/V,N
+INC SP	6	7	2	33	1	SP				SP
+JP HL	4	5	1	E9	1	HL				PC
+JP (HL)	4	5	1	E9	1	HL				PC
+LD (BC),A	7	8	2	2	1	A,BC							BC
+LD (DE),A	7	8	2	12	1	A,DE							DE
+LD (HL),r	7	8	2	70+r	1	r,HL							HL
+LD A,(BC)	7	8	2	0A	1	BC			BC	A
+LD A,(DE)	7	8	2	1A	1	DE			DE	A
+LD A,(HL)	7	8	2	7E	1	HL			HL	A
+LD A,r	4	5	1	78+r	1	r				A
+LD B,(HL)	7	8	2	46	1	HL			HL	B
+LD B,r	4	5	1	40+r	1	r				B
+LD C,(HL)	7	8	2	4E	1	HL			HL	C
+LD C,r	4	5	1	48+r	1	r				C
+LD D,(HL)	7	8	2	56	1	HL			HL	D
+LD D,r	4	5	1	50+r	1	r				D
+LD E,(HL)	7	8	2	5E	1	HL			HL	E
+LD E,r	4	5	1	58+r	1	r				E
+LD H,(HL)	7	8	2	66	1	HL			HL	H
+LD H,r	4	5	1	60+r	1	r				H
+LD L,(HL)	7	8	2	6E	1	HL			HL	L
+LD L,r	4	5	1	68+r	1	r				L
+LD SP,HL	6	7	2	F9	1	HL				SP
+NOP	4	5	1	0	1
+OR (HL)	7	8	2	B6	1	A,HL			HL	A	S,Z,H,P/V,N,C
+OR r	4	5	1	B0+r	1	A,r				A	S,Z,H,P/V,N,C
+POP AF	10	11	3	F1	1	SP			[SP:SP+1]	AF,SP
+POP BC	10	11	3	C1	1	SP			[SP:SP+1]	BC,SP
+POP DE	10	11	3	D1	1	SP			[SP:SP+1]	DE,SP
+POP HL	10	11	3	E1	1	SP			[SP:SP+1]	HL,SP
+PUSH AF	11	12	4	F5	1	AF,SP				SP			[SP-2:SP-1]
+PUSH BC	11	12	4	C5	1	BC,SP				SP			[SP-2:SP-1]
+PUSH DE	11	12	4	D5	1	DE,SP				SP			[SP-2:SP-1]
+PUSH HL	11	12	4	E5	1	HL,SP				SP			[SP-2:SP-1]
+RET	10	11	3	C9	1	SP			[SP:SP+1]	SP,PC
+RET C	5/11	6/12	2/4	D8	1	SP	C		[SP:SP+1]	SP,PC
+RET M	5/11	6/12	2/4	F8	1	SP	S		[SP:SP+1]	SP,PC
+RET NC	5/11	6/12	2/4	D0	1	SP	C		[SP:SP+1]	SP,PC
+RET NZ	5/11	6/12	2/4	C0	1	SP	Z		[SP:SP+1]	SP,PC
+RET P	5/11	6/12	2/4	F0	1	SP	S		[SP:SP+1]	SP,PC
+RET PE	5/11	6/12	2/4	E8	1	SP	P		[SP:SP+1]	SP,PC
+RET PO	5/11	6/12	2/4	E0	1	SP	P		[SP:SP+1]	SP,PC
+RET Z	5/11	6/12	2/4	C8	1	SP	Z		[SP:SP+1]	SP,PC
+RLA	4	5	1	17	1	A	C			A	H,N,C
+RLCA	4	5	1	7	1	A				A	H,N,C
+RRA	4	5	1	1F	1	A	C			A	H,N,C
+RRCA	4	5	1	0F	1	A				A	H,N,C
+RST 0	11	12	4	C7	1	SP				SP,PC			[SP-2:SP-1]
+RST 10H	11	12	4	D7	1	SP				SP,PC			[SP-2:SP-1]
+RST 18H	11	12	4	DF	1	SP				SP,PC			[SP-2:SP-1]
+RST 20H	11	12	4	E7	1	SP				SP,PC			[SP-2:SP-1]
+RST 28H	11	12	4	EF	1	SP				SP,PC			[SP-2:SP-1]
+RST 30H	11	12	4	F7	1	SP				SP,PC			[SP-2:SP-1]
+RST 38H	11	12	4	FF	1	SP				SP,PC			[SP-2:SP-1]
+RST 8H	11	12	4	CF	1	SP				SP,PC			[SP-2:SP-1]
+SBC A,(HL)	7	8	2	9E	1	A,HL	C		HL	A	S,Z,H,P/V,N,C
+SBC A,A	4	5	1	98+r	1		C			A	S,Z,H,P/V,N,C
+SBC A,B	4	5	1	98+r	1	A,B	C			A	S,Z,H,P/V,N,C
+SBC A,C	4	5	1	98+r	1	A,C	C			A	S,Z,H,P/V,N,C
+SBC A,D	4	5	1	98+r	1	A,D	C			A	S,Z,H,P/V,N,C
+SBC A,E	4	5	1	98+r	1	A,E	C			A	S,Z,H,P/V,N,C
+SBC A,H	4	5	1	98+r	1	A,H	C			A	S,Z,H,P/V,N,C
+SBC A,L	4	5	1	98+r	1	A,L	C			A	S,Z,H,P/V,N,C
+SCF	4	5	1	37	1						H,N,C
+SUB (HL)	7	8	2	96	1	A,HL			HL	A	S,Z,H,P/V,N,C
+SUB A	4	5	1	90+r	1					A	S,Z,H,P/V,N,C
+SUB B	4	5	1	90+r	1	A,B				A	S,Z,H,P/V,N,C
+SUB C	4	5	1	90+r	1	A,C				A	S,Z,H,P/V,N,C
+SUB D	4	5	1	90+r	1	A,D				A	S,Z,H,P/V,N,C
+SUB E	4	5	1	90+r	1	A,E				A	S,Z,H,P/V,N,C
+SUB H	4	5	1	90+r	1	A,H				A	S,Z,H,P/V,N,C
+SUB L	4	5	1	90+r	1	A,L				A	S,Z,H,P/V,N,C
+XOR (HL)	7	8	2	AE	1	A,HL			HL	A	S,Z,H,P/V,N,C
+XOR A	4	5	1	A8+7	1					A	S,Z,H,P/V,N,C
+XOR B	4	5	1	A8+0	1	A,B				A	S,Z,H,P/V,N,C
+XOR C	4	5	1	A8+1	1	A,C				A	S,Z,H,P/V,N,C
+XOR D	4	5	1	A8+2	1	A,D				A	S,Z,H,P/V,N,C
+XOR E	4	5	1	A8+3	1	A,E				A	S,Z,H,P/V,N,C
+XOR H	4	5	1	A8+4	1	A,H				A	S,Z,H,P/V,N,C
+XOR L	4	5	1	A8+5	1	A,L				A	S,Z,H,P/V,N,C
+ADC A,IXp	8	10	2	DD 88+p	2	A,IXp	C			A	S,Z,H,P/V,N,C
+ADC A,IYq	8	10	2	FD 88+q	2	A,IYq	C			A	S,Z,H,P/V,N,C
+ADC A,n	7	8	2	CE n	2	A	C			A	S,Z,H,P/V,N,C
+ADC HL,BC	15	17	4	ED 4A	2	HL,BC	C			HL	S,Z,H,P/V,N,C
+ADC HL,DE	15	17	4	ED 5A	2	HL,DE	C			HL	S,Z,H,P/V,N,C
+ADC HL,HL	15	17	4	ED 6A	2	HL	C			HL	S,Z,H,P/V,N,C
+ADC HL,SP	15	17	4	ED 7A	2	HL,SP	C			HL	S,Z,H,P/V,N,C
+ADD A,IXp	8	10	2	DD 80+p	2	A,IXp				A	S,Z,H,P/V,N,C
+ADD A,IYq	8	10	2	FD 80+q	2	A,IYq				A	S,Z,H,P/V,N,C
+ADD A,n	7	8	2	C6 n	2	A				A	S,Z,H,P/V,N,C
+ADD IX,BC	15	17	4	DD 09	2	IX,BC				IX	H,N,C
+ADD IX,DE	15	17	4	DD 19	2	IX,DE				IX	H,N,C
+ADD IX,IX	15	17	4	DD 29	2	IX				IX	H,N,C
+ADD IX,SP	15	17	4	DD 39	2	IX,SP				IX	H,N,C
+ADD IY,BC	15	17	4	FD 09	2	IY,BC				IY	H,N,C
+ADD IY,DE	15	17	4	FD 19	2	IY,DE				IY	H,N,C
+ADD IY,IY	15	17	4	FD 29	2	IY				IY	H,N,C
+ADD IY,SP	15	17	4	FD 39	2	IY,SP				IY	H,N,C
+AND IXp	8	10	2	DD A0+p	2	A,IXp				A	S,Z,H,P/V,N,C
+AND IYq	8	10	2	FD A0+q	2	A,IYq				A	S,Z,H,P/V,N,C
+AND n	7	8	2	E6 n	2	A				A	S,Z,H,P/V,N,C
+BIT b,(HL)	12	14	3	CB 46+8*b	2	HL			HL		S,Z,H,P/V,N
+BIT b,r	8	10	2	CB 40+8*b+r	2	r					S,Z,H,P/V,N
+CP IXp	8	10	2	DD B8+p	2	A,IXp					S,Z,H,P/V,N,C
+CP IYq	8	10	2	FD B8+q	2	A,IYq					S,Z,H,P/V,N,C
+CP n	7	8	2	FE n	2	A					S,Z,H,P/V,N,C
+CPD	16	18	5	ED A9	2	A,HL,BC			HL	HL,BC	S,Z,H,P/V,N
+CPDR	21/16	23/18	6/5	ED B9	2	A,HL,BC			[HL-B:HL]	HL,BC	S,Z,H,P/V,N
+CPI	16	18	5	ED A1	2	A,HL,BC			HL	HL,BC	S,Z,H,P/V,N
+CPIR	21/16	23/18	6/5	ED B1	2	A,HL,BC			[HL:HL+B]	HL,BC	S,Z,H,P/V,N
+DEC IX	10	12	3	DD 2B	2	IX				IX
+DEC IXp	8	10	2	DD 05+8*p	2	IXp				IXp	S,Z,H,P/V,N
+DEC IY	10	12	3	FD 2B	2	IY				IY
+DEC IYq	8	10	2	FD 05+8*q	2	IYq				IYq	S,Z,H,P/V,N
+DJNZ o	13/8	14/9	4/3	10 o	2	B				B,PC
+EX (SP),IX	23	25	7	DD E3	2	HL,IX			[SP:SP+1]	IX			[SP:SP+1]
+EX (SP),IY	23	25	7	FD E3	2	HL,IY			[SP:SP+1]	IY			[SP:SP+1]
+IM 0	8	10	2	ED 46	2
+IM 1	8	10	2	ED 56	2
+IM 2	8	10	2	ED 5E	2
+IN A,(C)	12	14	4	ED 78	2			C		A	S,Z,N
+IN A,(n)	11	12	3	DB n	2			n		A	S,Z,N
+IN B,(C)	12	14	4	ED 40	2			C		B	S,Z,N
+IN C,(C)	12	14	4	ED 48	2			C		C	S,Z,N
+IN D,(C)	12	14	4	ED 50	2			C		D	S,Z,N
+IN E,(C)	12	14	4	ED 58	2			C		E	S,Z,N
+IN F,(C)	12	14	4	ED 70	2			C		F	S,Z,N
+IN H,(C)	12	14	4	ED 60	2			C		H	S,Z,N
+IN L,(C)	12	14	4	ED 68	2			C		L	S,Z,N
+INC IX	10	12	3	DD 23	2	IX				IX
+INC IXp	8	10	2	DD 04+8*p	2	IXp				IXp	S,Z,H,P/V,N
+INC IY	10	12	3	FD 23	2	IY				IY
+INC IYq	8	10	2	FD 04+8*q	2	IYq				IYq	S,Z,H,P/V,N
+IND	16	18	5	ED AA	2	HL,B,C		C		HL,B	S,Z,H,P/V,N,C		HL
+INDR	21/16	23/18	6/5	ED BA	2	HL,B,C		C		HL,B	S,Z,H,P/V,N,C		[HL-B:HL]
+INI	16	18	5	ED A2	2	HL,B,C		C		HL,B	S,Z,H,P/V,N,C		HL
+INIR	21/16	23/18	6/5	ED B2	2	HL,B,C		C		HL,B	S,Z,H,P/V,N,C		[HL:HL+B]
+JP IX	8	10	2	DD E9	2	IX				PC
+JP (IX)	8	10	2	DD E9	2	IX				PC
+JP IY	8	10	2	FD E9	2	IY				PC
+JP (IY)	8	10	2	FD E9	2	IY				PC
+JR C,o	7/12	13/8	3/2	38 o	2		C			PC
+JR NC,o	7/12	13/8	3/2	30 o	2		C			PC
+JR NZ,o	7/12	13/8	3/2	20 o	2		Z			PC
+JR Z,o	7/12	13/8	3/2	28 o	2		Z			PC
+JR o	12	13	3	18 o	2					PC
+LD (HL),n	10	11	3	36 n	2	HL							HL
+LD A,I	9	11	3	ED 57	2	I				A
+LD A,IXp	8	10	2	DD 78+p	2	IXp				A
+LD A,IYq	8	10	2	FD 78+q	2	IYq				A
+LD A,R	9	11	3	ED 5F	2	R				A
+LD A,n	7	8	2	3E n	2					A
+LD B,IXp	8	10	2	DD 40+p	2	IXp				B
+LD B,IYq	8	10	2	FD 40+q	2	IYq				B
+LD B,n	7	8	2	06 n	2					B
+LD C,IXp	8	10	2	DD 48+p	2	IXp				C
+LD C,IYq	8	10	2	FD 48+q	2	IYq				C
+LD C,n	7	8	2	0E n	2					C
+LD D,IXp	8	10	2	DD 50+p	2	IXp				D
+LD D,IYq	8	10	2	FD 50+q	2	IYq				D
+LD D,n	7	8	2	16 n	2					D
+LD E,IXp	8	10	2	DD 58+p	2	IXp				E
+LD E,IYq	8	10	2	FD 58+q	2	IYq				E
+LD E,n	7	8	2	1E n	2					E
+LD H,n	7	8	2	26 n	2					H
+LD I,A	9	11	3	ED 47	2	A				I
+LD IXh,p	8	10	3	DD 60+p	2	p				IXh
+LD IXl,p	8	10	3	DD 68+p	2	p				IXl
+LD IYh,q	8	10	3	FD 60+q	2	q				IYh
+LD IYl,q	8	10	3	FD 68+q	2	q				IYl
+LD L,n	7	8	2	2E n	2					L
+LD R,A	9	11	3	ED 4F	2	A				R
+LD SP,IX	10	12	3	DD F9	2	IX				SP
+LD SP,IY	10	12	3	FD F9	2	IY				SP
+LDD	16	18	5	ED A8	2	BC,DE,HL			HL	BC,HL	H,P/V,N		DE
+LDDR	21/16	23/18	6/5	ED B8	2	BC,DE,HL			[HL-BC:HL]	BC,DE,HL			[DE-BC:DE]
+LDI	16	18	5	ED A0	2	BC,DE,HL			HL	BC,HL	H,P/V,N		DE
+LDIR	21/16	23/18	6/5	ED B0	2	BC,DE,HL			[HL:HL+BC]	BC,DE,HL			[DE:DE+BC]
+NEG	8	10	2	ED 44	2	A				A	S,Z,H,P/V,N,C
+OR IXp	8	10	2	DD B0+p	2	A,IXp				A	S,Z,H,P/V,N,C
+OR IYq	8	10	2	FD B0+q	2	A,IYq				A	S,Z,H,P/V,N,C
+OR n	7	8	2	F6 n	2	A				A	S,Z,H,P/V,N,C
+OTDR	21/16	23/18	6/5	ED BB	2	B,C,HL			[HL-B:HL]	B,HL	S,Z,H,P/V,N,C	C
+OTIR	21/16	23/18	6/5	ED B3	2	B,C,HL			[HL:HL+B]	B,HL	S,Z,H,P/V,N,C	C
+OUT (C),A	12	14	4	ED 79	2	A,C					S,Z,N	C
+OUT (C),B	12	14	4	ED 41	2	B,C					S,Z,N	C
+OUT (C),C	12	14	4	ED 49	2	C					S,Z,N	C
+OUT (C),D	12	14	4	ED 51	2	C,D					S,Z,N	C
+OUT (C),E	12	14	4	ED 59	2	C,E					S,Z,N	C
+OUT (C),H	12	14	4	ED 61	2	C,H					S,Z,N	C
+OUT (C),L	12	14	4	ED 69	2	C,L					S,Z,N	C
+OUT (n),A	11	12	4	D3 n	2	A					S,Z,N	n
+OUTD	16	18	5	ED AB	2	B,C,HL			HL	B,HL	S,Z,H,P/V,N,C	C
+OUTI	16	18	5	ED A3	2	B,C,HL			HL	B,HL	S,Z,H,P/V,N,C	C
+POP IX	14	16	5	DD E1	2				[SP:SP+1]	IX,SP
+POP IY	14	16	5	FD E1	2				[SP:SP+1]	IY,SP
+PUSH IX	15	17	5	DD E5	2	IX				SP			[SP-2:SP-1]
+PUSH IY	15	17	5	FD E5	2	IY				SP			[SP-2:SP-1]
+RES b,(HL)	15	17	4	CB 86+8*b	2	HL			HL				HL
+RES b,r	8	10	2	CB 80+8*b+r	2	r				r
+RETI	14	16	4	ED 4D	2				[SP:SP+1]	SP,PC
+RETN	14	16	4	ED 45	2				[SP:SP+1]	SP,PC
+RL (HL)	15	17	4	CB 16	2	HL	C			HL	S,Z,H,P/V,N,C		HL
+RL r	8	10	2	CB 10+r	2	r	C				S,Z,H,P/V,N,C
+RLC (HL)	15	17	4	CB 06	2	HL				HL	S,Z,H,P/V,N,C		HL
+RLC r	8	10	2	CB 00+r	2	r					S,Z,H,P/V,N,C
+RLD	18	20	5	ED 6F	2	A					S,Z,H,P/V,N
+RR (HL)	15	17	4	CB 1E	2	HL	C			HL	S,Z,H,P/V,N,C		HL
+RR r	8	10	2	CB 18+r	2	r	C				S,Z,H,P/V,N,C
+RRC (HL)	15	17	4	CB 0E	2	HL				HL	S,Z,H,P/V,N,C		HL
+RRC r	8	10	2	CB 08+r	2	r					S,Z,H,P/V,N,C
+RRD	18	20	5	ED 67	2	A					S,Z,H,P/V,N
+SBC A,IXp	8	10	2	DD 98+p	2	A,IXp	C			A	S,Z,H,P/V,N,C
+SBC A,IYq	8	10	2	FD 98+q	2	A,IYq	C			A	S,Z,H,P/V,N,C
+SBC A,n	7	8	2	DE n	2	A	C			A	S,Z,H,P/V,N,C
+SBC HL,BC	15	17	4	ED 42	2	HL,BC	C			HL	S,Z,H,P/V,N,C
+SBC HL,DE	15	17	4	ED 52	2	HL,DE	C			HL	S,Z,H,P/V,N,C
+SBC HL,HL	15	17	4	ED 62	2	HL	C			HL	S,Z,H,P/V,N,C
+SBC HL,SP	15	17	4	ED 72	2	HL,SP	C			HL	S,Z,H,P/V,N,C
+SET b,(HL)	15	17	4	CB C6+8*b	2	HL			HL				HL
+SET b,r	8	10	2	CB C0+8*b+r	2	r				r
+SLA (HL)	15	17	4	CB 26	2	HL			HL		S,Z,H,P/V,N,C		HL
+SLA r	8	10	2	CB 20+r	2	r				r	S,Z,H,P/V,N,C
+SRA (HL)	15	17	4	CB 2E	2	HL			HL		S,Z,H,P/V,N,C		HL
+SRA r	8	10	2	CB 28+r	2	r				r	S,Z,H,P/V,N,C
+SRL (HL)	15	17	4	CB 3E	2	HL			HL		S,Z,H,P/V,N,C		HL
+SRL r	8	10	2	CB 38+r	2	r				r	S,Z,H,P/V,N,C
+SUB IXp	8	10	2	DD 90+p	2	A,IXp				A	S,Z,H,P/V,N,C
+SUB IYq	8	10	2	FD 90+q	2	A,IYq				A	S,Z,H,P/V,N,C
+SUB n	7	8	2	D6 n	2	A				A	S,Z,H,P/V,N,C
+XOR IXp	8	10	2	DD A8+p	2	A,IXp				A	S,Z,H,P/V,N,C
+XOR IYq	8	10	2	FD A8+q	2	A,IYq				A	S,Z,H,P/V,N,C
+XOR n	7	8	2	EE n	2	A				A	S,Z,H,P/V,N,C
+ADC A,(IX+o)	19	21	5	DD 8E o	3	A,IX	C		IX+o	A	S,Z,H,P/V,N,C
+ADC A,(IY+o)	19	21	5	FD 8E o	3	A,IY	C		IY+o	A	S,Z,H,P/V,N,C
+ADD A,(IX+o)	19	21	5	DD 86 o	3	A,IX			IX+o	A	S,Z,H,P/V,N,C
+ADD A,(IY+o)	19	21	5	FD 86 o	3	A,IY			IY+o	A	S,Z,H,P/V,N,C
+AND (IX+o)	19	21	5	DD A6 o	3	A,IX			IX+o	A	S,Z,H,P/V,N,C
+AND (IY+o)	19	21	5	FD A6 o	3	A,IY			IY+o	A	S,Z,H,P/V,N,C
+CALL C,nn	17/10	18/11	5/3	DC nn nn	3	SP	C			SP,PC			[SP-2:SP-1]
+CALL M,nn	17/10	18/11	5/3	FC nn nn	3	SP	S			SP,PC			[SP-2:SP-1]
+CALL NC,nn	17/10	18/11	5/3	D4 nn nn	3	SP	C			SP,PC			[SP-2:SP-1]
+CALL NZ,nn	17/10	18/11	5/3	C4 nn nn	3	SP	Z			SP,PC			[SP-2:SP-1]
+CALL P,nn	17/10	18/11	5/3	F4 nn nn	3	SP	S			SP,PC			[SP-2:SP-1]
+CALL PE,nn	17/10	18/11	5/3	EC nn nn	3	SP	P/V			SP,PC			[SP-2:SP-1]
+CALL PO,nn	17/10	18/11	5/3	E4 nn nn	3	SP	P/V			SP,PC			[SP-2:SP-1]
+CALL Z,nn	17/10	18/11	5/3	CC nn nn	3	SP	Z			SP,PC			[SP-2:SP-1]
+CALL nn	17	18	5	CD nn nn	3	SP				SP,PC			[SP-2:SP-1]
+CP (IX+o)	19	21	5	DD BE o	3	A,IX			IX+o		S,Z,H,P/V,N,C
+CP (IY+o)	19	21	5	FD BE o	3	A,IY			IY+o		S,Z,H,P/V,N,C
+DEC (IX+o)	23	25	6	DD 35 o	3	IX			IX+o		S,Z,H,P/V,N		IX+o
+DEC (IY+o)	23	25	6	FD 35 o	3	IY			IY+o		S,Z,H,P/V,N		IY+o
+INC (IX+o)	23	25	6	DD 34 o	3	IX			IX+o		S,Z,H,P/V,N		IX+o
+INC (IY+o)	23	25	6	FD 34 o	3	IY			IY+o		S,Z,H,P/V,N		IY+o
+JP C,nn	10	11	3	DA nn nn	3		C			PC
+JP M,nn	10	11	3	FA nn nn	3		S			PC
+JP NC,nn	10	11	3	D2 nn nn	3		C			PC
+JP NZ,nn	10	11	3	C2 nn nn	3		Z			PC
+JP P,nn	10	11	3	F2 nn nn	3		S			PC
+JP PE,nn	10	11	3	EA nn nn	3		P/V			PC
+JP PO,nn	10	11	3	E2 nn nn	3		P/V			PC
+JP Z,nn	10	11	3	CA nn nn	3		Z			PC
+JP nn	10	11	3	C3 nn nn	3					PC
+LD (IX+o),r	19	21	5	DD 70+r o	3	IX,r							IX+o
+LD (IY+o),r	19	21	5	FD 70+r o	3	IY,r							IY+o
+LD (nn),A	13	14	4	32 nn nn	3	A							nn
+LD (nn),HL	16	17	5	22 nn nn	3	HL							[nn:nn+1]
+LD A,(IX+o)	19	21	5	DD 7E o	3	IX			IX+o	A
+LD A,(IY+o)	19	21	5	FD 7E o	3	IY			IY+o	A
+LD A,(nn)	13	14	4	3A nn nn	3				nn	A
+LD B,(IX+o)	19	21	5	DD 46 o	3	IX			IX+o	B
+LD B,(IY+o)	19	21	5	FD 46 o	3	IY			IY+o	B
+LD BC,nn	10	11	3	01 nn nn	3					BC
+LD C,(IX+o)	19	21	5	DD 4E o	3	IX			IX+o	C
+LD C,(IY+o)	19	21	5	FD 4E o	3	IY			IY+o	C
+LD D,(IX+o)	19	21	5	DD 56 o	3	IX			IX+o	D
+LD D,(IY+o)	19	21	5	FD 56 o	3	IY			IY+o	D
+LD DE,nn	10	11	3	11 nn nn	3					DE
+LD E,(IX+o)	19	21	5	DD 5E o	3	IX			IX+o	E
+LD E,(IY+o)	19	21	5	FD 5E o	3	IY			IY+o	E
+LD H,(IX+o)	19	21	5	DD 66 o	3	IX			IX+o	H
+LD H,(IY+o)	19	21	5	FD 66 o	3	IY			IY+o	H
+LD HL,(nn)	16	17	5	2A nn nn	3				[nn:nn+1]	HL
+LD HL,nn	10	11	3	21 nn nn	3					HL
+LD IXh,n	11	13	3	DD 26 n	3					IXh
+LD IXl,n	11	13	3	DD 2E n	3					IXl
+LD IYh,n	11	13	3	FD 26 n	3					IYh
+LD IYl,n	11	13	3	FD 2E n	3					IYl
+LD L,(IX+o)	19	21	5	DD 6E o	3	IX			IX+o	L
+LD L,(IY+o)	19	21	5	FD 6E o	3	IY			IY+o	L
+LD SP,nn	10	11	3	31 nn nn	3					SP
+OR (IX+o)	19	21	5	DD B6 o	3	A,IX			IX+o	A	S,Z,H,P/V,N,C
+OR (IY+o)	19	21	5	FD B6 o	3	A,IY			IY+o	A	S,Z,H,P/V,N,C
+SBC A,(IX+o)	19	21	5	DD 9E o	3	A,IX	C		IX+o	A	S,Z,H,P/V,N,C
+SBC A,(IY+o)	19	21	5	FD 9E o	3	A,IY	C		IY+o	A	S,Z,H,P/V,N,C
+SUB (IX+o)	19	21	5	DD 96 o	3	A,IX			IX+o	A	S,Z,H,P/V,N,C
+SUB (IY+o)	19	21	5	FD 96 o	3	A,IY			IY+o	A	S,Z,H,P/V,N,C
+XOR (IX+o)	19	21	5	DD AE o	3	A,IX			IX+o	A	S,Z,H,P/V,N,C
+XOR (IY+o)	19	21	5	FD AE o	3	A,IY			IY+o	A	S,Z,H,P/V,N,C
+BIT b,(IX+o)	20	22	6	DD CB o 46+8*b	4	IX			IX+o		S,Z,H,P/V,N
+BIT b,(IY+o)	20	22	6	FD CB o 46+8*b	4	IY			IY+o		S,Z,H,P/V,N
+LD (IX+o),n	19	21	6	DD 36 o n	4	IX							IX+o
+LD (IY+o),n	19	21	6	FD 36 o n	4	IY							IY+o
+LD (nn),BC	20	22	6	ED 43 nn nn	4	BC							[nn:nn+1]
+LD (nn),DE	20	22	6	ED 53 nn nn	4	DE							[nn:nn+1]
+LD (nn),IX	20	22	6	DD 22 nn nn	4	IX							[nn:nn+1]
+LD (nn),IY	20	22	6	FD 22 nn nn	4	IY							[nn:nn+1]
+LD (nn),SP	20	22	6	ED 73 nn nn	4	SP							[nn:nn+1]
+LD BC,(nn)	20	22	6	ED 4B nn nn	4				[nn:nn+1]	BC
+LD DE,(nn)	20	22	6	ED 5B nn nn	4				[nn:nn+1]	DE
+LD IX,(nn)	20	22	6	DD 2A nn nn	4				[nn:nn+1]	IX
+LD IX,nn	14	16	4	DD 21 nn nn	4					IX
+LD IY,(nn)	20	22	6	FD 2A nn nn	4				[nn:nn+1]	IY
+LD IY,nn	14	16	4	FD 21 nn nn	4					IY
+LD SP,(nn)	20	22	6	ED 7B nn nn	4				[nn:nn+1]	SP
+RES b,(IX+o)	23	25	7	DD CB o 86+8*b	4	IX			IX+o				IX+o
+RES b,(IY+o)	23	25	7	FD CB o 86+8*b	4	IY			IY+o				IY+o
+RL (IX+o)	23	25	7	DD CB o 16	4	IX	C		IX+o		S,Z,H,P/V,N,C		IX+o
+RL (IY+o)	23	25	7	FD CB o 16	4	IY	C		IY+o		S,Z,H,P/V,N,C		IY+o
+RLC (IX+o)	23	25	7	DD CB o 06	4	IX			IX+o		S,Z,H,P/V,N,C		IX+o
+RLC (IY+o)	23	25	7	FD CB o 06	4	IY			IY+o		S,Z,H,P/V,N,C		IY+o
+RR (IX+o)	23	25	7	DD CB o 1E	4	IX	C		IX+o		S,Z,H,P/V,N,C		IX+o
+RR (IY+o)	23	25	7	FD CB o 1E	4	IY	C		IY+o		S,Z,H,P/V,N,C		IY+o
+RRC (IX+o)	23	25	7	DD CB o 0E	4	IX			IX+o		S,Z,H,P/V,N,C		IX+o
+RRC (IY+o)	23	25	7	FD CB o 0E	4	IY			IY+o		S,Z,H,P/V,N,C		IY+o
+SET b,(IX+o)	23	25	7	DD CB o C6+8*b	4	IX			IX+o				IX+o
+SET b,(IY+o)	23	25	7	FD CB o C6+8*b	4	IY			IY+o				IY+o
+SLA (IX+o)	23	25	7	DD CB o 26	4	IX			IX+o		S,Z,H,P/V,N,C		IX+o
+SLA (IY+o)	23	25	7	FD CB o 26	4	IY			IY+o		S,Z,H,P/V,N,C		IY+o
+SRA (IX+o)	23	25	7	DD CB o 2E	4	IX			IX+o		S,Z,H,P/V,N,C		IX+o
+SRA (IY+o)	23	25	7	FD CB o 2E	4	IY			IY+o		S,Z,H,P/V,N,C		IY+o
+SRL (IX+o)	23	25	7	DD CB o 3E	4	IX			IX+o		S,Z,H,P/V,N,C		IX+o
+SRL (IY+o)	23	25	7	FD CB o 3E	4	IY			IY+o		S,Z,H,P/V,N,C		IY+o
+; Unofficial alternative way to write some instructions that some assemblers support:
+ADC (HL)	7	8	2	8E	1	A,HL	C		HL	A	S,Z,H,P/V,N,C
+ADC r	4	5	1	88+r	1	A,r	C			A	S,Z,H,P/V,N,C
+ADC n	7	8	2	CE n	2	A	C			A	S,Z,H,P/V,N,C
+ADC (IX+o)	19	21	5	DD 8E o	3	A,IX	C		IX+o	A	S,Z,H,P/V,N,C
+ADC (IY+o)	19	21	5	FD 8E o	3	A,IY	C		IY+o	A	S,Z,H,P/V,N,C
+ADD r	4	5	1	80+r	1	A,r				A	S,Z,H,P/V,N,C
+ADD (HL)	7	8	2	86	1	A,HL			HL	A	S,Z,H,P/V,N,C
+ADD n	7	8	2	C6 n	2	A				A	S,Z,H,P/V,N,C
+ADD (IX+o)	19	21	5	DD 86 o	3	A,IX			IX+o	A	S,Z,H,P/V,N,C
+ADD (IY+o)	19	21	5	FD 86 o	3	A,IY			IY+o	A	S,Z,H,P/V,N,C
+EX HL,DE	4	5	1	EB	1	DE,HL				DE,HL
+OUT n,A	11	12	4	D3 n	2	A					S,Z,N	n
+SBC (HL)	7	8	2	9E	1	A,HL	C		HL	A	S,Z,H,P/V,N,C
+SBC A	4	5	1	98+r	1		C			A	S,Z,H,P/V,N,C
+SBC B	4	5	1	98+r	1	A,B	C			A	S,Z,H,P/V,N,C
+SBC C	4	5	1	98+r	1	A,C	C			A	S,Z,H,P/V,N,C
+SBC D	4	5	1	98+r	1	A,D	C			A	S,Z,H,P/V,N,C
+SBC E	4	5	1	98+r	1	A,E	C			A	S,Z,H,P/V,N,C
+SBC H	4	5	1	98+r	1	A,H	C			A	S,Z,H,P/V,N,C
+SBC L	4	5	1	98+r	1	A,L	C			A	S,Z,H,P/V,N,C
+SUB A, (HL)	7	8	2	96	1	A,HL			HL	A	S,Z,H,P/V,N,C
+SUB A, A	4	5	1	90+r	1					A	S,Z,H,P/V,N,C
+SUB A, B	4	5	1	90+r	1	A,B				A	S,Z,H,P/V,N,C
+SUB A, C	4	5	1	90+r	1	A,C				A	S,Z,H,P/V,N,C
+SUB A, D	4	5	1	90+r	1	A,D				A	S,Z,H,P/V,N,C
+SUB A, E	4	5	1	90+r	1	A,E				A	S,Z,H,P/V,N,C
+SUB A, H	4	5	1	90+r	1	A,H				A	S,Z,H,P/V,N,C
+SUB A, L	4	5	1	90+r	1	A,L				A	S,Z,H,P/V,N,C


### PR DESCRIPTION
This pull request includes more alternative syntax found in the wild (mostly from really permissive asMSX syntax). Sorry about line endings messed up; really don't know how to prevent it :(

It also should fix the problem when the include paths are declared in a relative manner ('-I ..\..' ), and looks for included files relative to current directory, to the "parent" source, and to the declared include paths.

(and yes, this pull request should have been two separate pull requests... :-/ )