### PR TITLE
Preliminary tniASM syntax support

### DIFF
--- a/src/main/java/parser/ExpressionParser.java
+++ b/src/main/java/parser/ExpressionParser.java
@@ -10,15 +10,17 @@ import code.CodeBase;
 import code.Expression;
 import code.SourceStatement;
 import java.util.ArrayList;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class ExpressionParser {
     MDLConfig config;
-    
+
     // make sure to add functions in lower case into this list:
     public List<String> dialectFunctions = new ArrayList<>();
-    
-    
+
+
     public ExpressionParser(MDLConfig a_config)
     {
         config = a_config;
@@ -90,7 +92,7 @@ public class ExpressionParser {
                 exp = Expression.operatorExpression(Expression.EXPRESSION_DIV, exp, exp2, config);
                 continue;
             }
-            if (tokens.get(0).equals("%")) {
+            if (StringUtils.equalsAnyIgnoreCase(tokens.get(0), "%", "MOD")) { // "MOD" is tniASM syntax
                 tokens.remove(0);
                 Expression exp2 = parseInternal(tokens, s, code);
                 if (exp2 == null) {
@@ -100,7 +102,7 @@ public class ExpressionParser {
                 exp = Expression.operatorExpression(Expression.EXPRESSION_MOD, exp, exp2, config);
                 continue;
             }
-            if (tokens.get(0).equals("|")) {
+            if (StringUtils.equalsAnyIgnoreCase(tokens.get(0), "|", "OR")) { // "OR" is tniASM syntax
                 tokens.remove(0);
                 Expression exp2 = parseInternal(tokens, s, code);
                 if (exp2 == null) {
@@ -110,7 +112,7 @@ public class ExpressionParser {
                 exp = Expression.operatorExpression(Expression.EXPRESSION_BITOR, exp, exp2, config);
                 continue;
             }
-            if (tokens.get(0).equals("&")) {
+            if (StringUtils.equalsAnyIgnoreCase(tokens.get(0), "&", "AND")) { // "AND" is tniASM syntax
                 tokens.remove(0);
                 Expression exp2 = parseInternal(tokens, s, code);
                 if (exp2 == null) {
@@ -120,7 +122,7 @@ public class ExpressionParser {
                 exp = Expression.operatorExpression(Expression.EXPRESSION_BITAND, exp, exp2, config);
                 continue;
             }
-            if (tokens.get(0).equals("^")) {
+            if (StringUtils.equalsAnyIgnoreCase(tokens.get(0), "^", "XOR")) { // "XOR" is tniASM syntax
                 tokens.remove(0);
                 Expression exp2 = parseInternal(tokens, s, code);
                 if (exp2 == null) {
@@ -315,7 +317,7 @@ public class ExpressionParser {
             Tokenizer.isSymbol(tokens.get(0))) {
             // symbol:
             String token = tokens.remove(0);
-            
+
             if (dialectFunctions.contains(token.toLowerCase())) {
                 String functionName = token;
                 List<Expression> args = new ArrayList<>();
@@ -334,14 +336,14 @@ public class ExpressionParser {
                         if (!first) {
                             if (tokens.isEmpty() || !tokens.get(0).equals(",")) {
                                 config.error("Failed to parse argument list of a dialect function.");
-                                return null;                                
+                                return null;
                             }
                             tokens.remove(0);
                         }
                         Expression arg = parse(tokens, s, code);
                         if (arg == null) {
                             config.error("Failed to parse argument list of a dialect function.");
-                            return null;                            
+                            return null;
                         }
                         args.add(arg);
                         first = false;
@@ -358,8 +360,8 @@ public class ExpressionParser {
                 if (config.dialectParser != null) token = config.dialectParser.symbolName(token);
                 return Expression.symbolExpression(token, code, config);
             }
-        }        
-        if (tokens.size() >= 2 && 
+        }
+        if (tokens.size() >= 2 &&
             (tokens.get(0).equals("%"))) {
             // should be a binary constant:
             String token = tokens.get(1);
@@ -384,7 +386,7 @@ public class ExpressionParser {
             }
         }
         if (tokens.size() >= 2 &&
-            tokens.get(0).equals("~")) {
+            StringUtils.equalsAnyIgnoreCase(tokens.get(0), "~", "NOT")) { // "NOT" is tniASM syntax
             // a bit negated expression:
             tokens.remove(0);
             Expression exp = parseInternal(tokens, s, code);

--- a/src/main/java/parser/SourceMacro.java
+++ b/src/main/java/parser/SourceMacro.java
@@ -20,6 +20,7 @@ public class SourceMacro {
     public static final String MACRO_ENDR = "endr";
     public static final String MACRO_IF = "if";
     public static final String MACRO_IFDEF = "ifdef";
+    public static final String MACRO_IFEXIST = "ifexist"; // tniASM syntax
     public static final String MACRO_ELSE = "else";
     public static final String MACRO_ENDIF = "endif";
 

--- a/src/main/java/parser/dialects/Dialect.java
+++ b/src/main/java/parser/dialects/Dialect.java
@@ -16,39 +16,62 @@ import parser.SourceMacro;
  * @author santi
  */
 public interface Dialect {
-    // Returns true if the line represented by "tokens" is recognized by this dialect parser
-    public boolean recognizeIdiom(List<String> tokens);
 
-    // Called when a new symbol is defined (so that the dialect parser can do whatever special it
-    // needs to do with it, e.g. define local labels, etc.)
-    // Returns false if we are trying to redefine a pre-defined symbol according to this dialect
-    public String newSymbolName(String name, Expression value);
+    /**
+     * @return true if the line represented by "tokens" is recognized by this dialect parser
+     */
+    boolean recognizeIdiom(List<String> tokens);
 
-    // Like the previous function, but called just when a symbol is used, not when it is defined
-    // Should return the actual symbol name (e.g., just "name" if this is an absolute symbol,
-    // or some concatenation with a prefix if it's a relative symbol)
-    public String symbolName(String name);
+    /**
+     * Called when a new symbol is defined (so that the dialect parser can do whatever special it
+     * needs to do with it, e.g. define local labels, etc.)
+     * @return false if we are trying to redefine a pre-defined symbol according to this dialect
+     */
+    String newSymbolName(String name, Expression value);
 
-    // If the previous function returns true, instead of trying to parse the line with the
-    // default parser, this function will be invoked instead. Returns true if it could
-    // successfully parse the line
-    // - returns "null" if an error occurred
-    // - otherwise, a list of statements to add as a result of parsing the line
-    public List<SourceStatement> parseLine(List<String> tokens,
+    /**
+     * Like {@link #newSymbolName the previous function}, but called just when a symbol is used, not when it is defined
+     * Should return the actual symbol name (e.g., just "name" if this is an absolute symbol,
+     * or some concatenation with a prefix if it's a relative symbol)
+     */
+    String symbolName(String name);
+
+    /**
+     * If the previous function returns true, instead of trying to parse the line with the
+     * default parser, this function will be invoked instead. Returns true if it could
+     * successfully parse the line
+     * @return {@code null} if an error occurred;
+     * a list of statements to add as a result of parsing the line otherwise
+     */
+    List<SourceStatement> parseLine(List<String> tokens,
             String line, int lineNumber,
             SourceStatement s, SourceFile source, CodeBase code);
 
-    // Some dialects might do special things when macros are defined. For example,
-    // Glass actually compiles the code inside macros, rather than treating it simply as
-    // text to be copy/pasted when the macro is expanded (as the default parser of MDL does).
-    // - returns "false" if an error occurred
-    public boolean newMacro(SourceMacro macro, CodeBase code);
-    
-    // Some dialectss implement custom functions (e.g., asMSX has a "random" function). They cannot
-    // be included in the general parser, as if someone uses a different assembler, those could be used
-    // as macro names, causing a collision. So, they are implemented via this function:
-    public Integer evaluateExpression(String functionName, List<Expression> args, SourceStatement s, CodeBase code, boolean silent);
-        
-    // Called after all the code is parsed and all macros expanded:
-    public void performAnyFinalActions(CodeBase code);
+    /**
+     * Some dialects might do special things when macros are defined. For example,
+     * Glass actually compiles the code inside macros, rather than treating it simply as
+     * text to be copy/pasted when the macro is expanded (as the default parser of MDL does).
+     * @return false if an error occurred
+     */
+    default boolean newMacro(SourceMacro macro, CodeBase code) {
+        // (no-op by default)
+        return true;
+    }
+
+    /**
+     * Some dialects implement custom functions (e.g., asMSX has a "random" function). They cannot
+     * be included in the general parser, as if someone uses a different assembler, those could be used
+     * as macro names, causing a collision. So, they are implemented via this function:
+     */
+    default Integer evaluateExpression(String functionName, List<Expression> args, SourceStatement s, CodeBase code, boolean silent) {
+        // (no-op by default)
+        return null;
+    }
+
+    /**
+     * Called after all the code is parsed and all macros expanded
+     */
+    default void performAnyFinalActions(CodeBase code) {
+        // (no-op by default)
+    }
 }

--- a/src/main/java/parser/dialects/Dialects.java
+++ b/src/main/java/parser/dialects/Dialects.java
@@ -1,0 +1,58 @@
+package parser.dialects;
+
+import org.apache.commons.lang3.StringUtils;
+
+import cl.MDLConfig;
+
+/**
+ * Utility class to handle dialect identifier strings
+ */
+public class Dialects {
+
+	/**
+	 * @return the default dialect identifier string
+	 */
+	public static String defaultDialect() {
+		return knownDialects()[0];
+	}
+
+	/**
+	 * @return the known dialect identifier strings
+	 */
+	public static String[] knownDialects() {
+		return new String[] { "mdl", "asmsx", "glass", "sjasm", "tniasm" };
+	}
+
+	/**
+	 * @param dialect a dialect candidate
+	 * @return a known dialect, or {@code null} if the candidate is not a known dialect
+	 */
+	public static String asKnownDialect(String dialect) {
+
+		return StringUtils.equalsAnyIgnoreCase(dialect, knownDialects())
+				? StringUtils.lowerCase(dialect)
+				: null;
+	}
+
+	/**
+	 * @param dialect a dialect candidate
+	 * @param mdlConfig MDLConfig instance
+	 * @return a Dialect instance for the requested dialect,
+	 * or {@code null} if the candidate is not a known dialect or has no Dialect implementation
+	 */
+	public static Dialect getDialectParser(String pDialect, MDLConfig mdlConfig) {
+
+		String dialect = asKnownDialect(pDialect);
+		if (dialect == null) {
+			return null;
+		}
+
+		switch (dialect) {
+			case "asmsx": return new ASMSXDialect(mdlConfig);
+			case "glass": return new GlassDialect(mdlConfig);
+			case "sjasm": return new SjasmDialect(mdlConfig);
+			case "tniasm": return new TniAsmDialect(mdlConfig);
+			default: return null;
+		}
+	}
+}

--- a/src/main/java/parser/dialects/TniAsmDialect.java
+++ b/src/main/java/parser/dialects/TniAsmDialect.java
@@ -1,0 +1,121 @@
+/*
+ * Author: Santiago Ontañón Villar (Brain Games)
+ */
+package parser.dialects;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import cl.MDLConfig;
+import code.CodeBase;
+import code.Expression;
+import code.SourceFile;
+import code.SourceStatement;
+
+/**
+ * tniASM 0.45 Dialect
+ * @author theNestruo
+ */
+public class TniAsmDialect implements Dialect {
+    /*
+     * FIXME The tniASM dialect is not functional yet!
+     */
+
+    /** tniASM keywords (lowercase) */
+    private final String[] keywords = { "org", "db", "dw", "dd", "ds" };
+
+    /** The minimum number of tokens for each {@link #keywords tniASM keyword} */
+    private final int[] minTokens = { 2, 2, 2, 2, 2 };
+
+    private final MDLConfig config;
+
+    private String lastAbsoluteLabel;
+
+    /**
+     * Constructor
+     */
+    public TniAsmDialect(MDLConfig a_config) {
+        super();
+
+        config = a_config;
+
+        lastAbsoluteLabel = null;
+    }
+
+
+    @Override
+    public boolean recognizeIdiom(List<String> tokens) {
+        return getKeyword(tokens) != null;
+    }
+
+
+    /**
+     * @param tokens the tokens
+     * @return one of the {@link #keywords}, if the first token matches the keyword and there are enough tokens;
+     * {@code null} otherwise
+     */
+    private String getKeyword(List<String> tokens) {
+
+        // (sanity check)
+        if ((tokens == null) || tokens.isEmpty()) {
+            return null;
+        }
+
+        int index = ArrayUtils.indexOf(keywords, StringUtils.lowerCase(tokens.iterator().next()));
+        return (index >= 0) && (tokens.size() >= minTokens[index])
+                ? keywords[index]
+                : null;
+    }
+
+
+    @Override
+    public String newSymbolName(String name, Expression value) {
+
+        // A keyword
+        if (StringUtils.equalsAnyIgnoreCase(name, keywords)) {
+            return null;
+        }
+
+        // A relative label
+        if (StringUtils.startsWith(name, ".")) {
+            return lastAbsoluteLabel + name;
+        }
+
+        // $ (??)
+        if ((value != null)
+                && (value.type == Expression.EXPRESSION_SYMBOL)
+                && value.symbolName.equalsIgnoreCase(CodeBase.CURRENT_ADDRESS)) {
+            lastAbsoluteLabel = name;
+        }
+
+        // An absolute label
+        return name;
+    }
+
+
+    @Override
+    public String symbolName(String name) {
+
+        return StringUtils.startsWith(name, ".")
+                ? lastAbsoluteLabel + name
+                : name;
+    }
+
+
+    @Override
+    public List<SourceStatement> parseLine(List<String> tokens,
+            String line, int lineNumber,
+            SourceStatement s, SourceFile source, CodeBase code)
+    {
+        String keyword = getKeyword(tokens);
+        if (keyword == null) {
+            return null;
+        }
+
+        tokens.remove(0);
+        return Collections.singletonList(s);
+    }
+}

--- a/src/main/java/workers/SymbolTableGenerator.java
+++ b/src/main/java/workers/SymbolTableGenerator.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import java.util.List;
 
 import cl.MDLConfig;
-import cl.MDLLogger;
 import code.CodeBase;
 import code.Expression;
 import code.SourceConstant;

--- a/src/main/java/workers/pattopt/CPUOpPattern.java
+++ b/src/main/java/workers/pattopt/CPUOpPattern.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import cl.MDLConfig;
-import cl.MDLLogger;
 import code.CPUOp;
 import code.CodeBase;
 import code.Expression;


### PR DESCRIPTION
Preliminary tniASM syntax support. **It is not completely functional yet!**

This pull request is a little/bit rough around the edges because `Dialect` cannot contain entire definition of a dialect (some parts of tniASM syntax support ended up in `ExpresisonParser` and `PreProcessor`/`SourceMacro`...)

At the moment, [lib/msx/cartridge.asm](https://github.com/theNestruo/msx-msxlib/blob/master/lib/msx/cartridge.asm) cannot be parsed. But I have been unable to understand the exact cause of problem... so I guess I'll make the pull request now and investigate further later O:-)

```
ERROR: File lib/msx/cartridge.asm ended while inside a macro definition of "if" at #12:
        org     $4000, $4000 + (CFG_INIT_ROM_SIZE * $0400) - 1
ERROR: Problem expanding macros after loading all the source code!
```