### PR TITLE
tniASM dialect improvements

### DIFF
--- a/src/main/java/parser/dialects/Dialect.java
+++ b/src/main/java/parser/dialects/Dialect.java
@@ -19,7 +19,10 @@ public interface Dialect {
 
 
     // @return true if the line represented by "tokens" is recognized by this dialect parser
-    boolean recognizeIdiom(List<String> tokens);
+    default boolean recognizeIdiom(List<String> tokens) {
+        // (no-op by default)
+        return false;
+    }
 
     // Called when a new symbol is defined (so that the dialect parser can do whatever special it
     // needs to do with it, e.g. define local labels, etc.)
@@ -36,9 +39,12 @@ public interface Dialect {
     // successfully parse the line
     // @return {@code null} if an error occurred;
     // a list of statements to add as a result of parsing the line otherwise
-    List<SourceStatement> parseLine(List<String> tokens,
+    default List<SourceStatement> parseLine(List<String> tokens,
             String line, int lineNumber,
-            SourceStatement s, SourceFile source, CodeBase code);
+            SourceStatement s, SourceFile source, CodeBase code) {
+        // (no-op by default)
+        return null;
+    }
 
     // Some dialects might do special things when macros are defined. For example,
     // Glass actually compiles the code inside macros, rather than treating it simply as

--- a/src/main/java/parser/dialects/TniAsmDialect.java
+++ b/src/main/java/parser/dialects/TniAsmDialect.java
@@ -4,30 +4,17 @@
 package parser.dialects;
 
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import cl.MDLConfig;
 import code.CodeBase;
 import code.Expression;
-import code.SourceFile;
-import code.SourceStatement;
-import java.util.List;
 
 /**
  * tniASM 0.45 Dialect
  * @author theNestruo
  */
 public class TniAsmDialect implements Dialect {
-    /*
-     * FIXME The tniASM dialect is not functional yet!
-     */
-
-    /** tniASM keywords (lowercase) */
-    private final String[] keywords = {};
-
-    /** The minimum number of tokens for each {@link #keywords tniASM keyword} */
-    private final int[] minTokens = {};
 
     private final MDLConfig config;
 
@@ -43,44 +30,16 @@ public class TniAsmDialect implements Dialect {
         config = a_config;
 
         lastAbsoluteLabel = null;
-        
+
         config.preProcessor.macroSynonyms.put("ifexist", config.preProcessor.MACRO_IFDEF);
-    }
 
-
-    @Override
-    public boolean recognizeIdiom(List<String> tokens) {
-        // We only need to return true for those that the default MDL parser would not recognize
-        return false;
-    }
-
-
-    /**
-     * @param tokens the tokens
-     * @return one of the {@link #keywords}, if the first token matches the keyword and there are enough tokens;
-     * {@code null} otherwise
-     */
-    private String getKeyword(List<String> tokens) {
-
-        // (sanity check)
-        if ((tokens == null) || tokens.isEmpty()) {
-            return null;
-        }
-
-        int index = ArrayUtils.indexOf(keywords, StringUtils.lowerCase(tokens.iterator().next()));
-        return (index >= 0) && (tokens.size() >= minTokens[index])
-                ? keywords[index]
-                : null;
+        config.lineParser.addKeywordSynonym("rb", config.lineParser.KEYWORD_DS);
+        config.lineParser.addKeywordSynonym("rw", config.lineParser.KEYWORD_DS); // FIXME misses implicit x2
     }
 
 
     @Override
     public String newSymbolName(String name, Expression value) {
-
-        // A keyword
-        if (StringUtils.equalsAnyIgnoreCase(name, keywords)) {
-            return null;
-        }
 
         // A relative label
         if (StringUtils.startsWith(name, ".")) {
@@ -106,16 +65,5 @@ public class TniAsmDialect implements Dialect {
         return StringUtils.startsWith(name, ".")
                 ? lastAbsoluteLabel + name
                 : name;
-    }
-
-
-    @Override
-    public List<SourceStatement> parseLine(List<String> tokens,
-            String line, int lineNumber,
-            SourceStatement s, SourceFile source, CodeBase code)
-    {
-        // We only need to react to dialect-specific keywords, standard keywords are already handled by the 
-        // standard MDL parser
-        return null;
     }
 }


### PR DESCRIPTION
Recognizes "rb" and "rw", and it is finally able to completely parse some sources here.

However, "rw" is probably wrong, as it misses the implicit multiplication by 2 of the size declared in the expression.