### PR TITLE
Fixes wrong condition and prevents test failure in Windows

### DIFF
--- a/src/main/java/code/CodeBase.java
+++ b/src/main/java/code/CodeBase.java
@@ -84,7 +84,7 @@ public class CodeBase {
                 if (sc.exp != null) {
                     // resolve it right away, before replacing:
                     Integer value = sc.exp.evaluate(sc.s, this, false);
-                    if (value != null) {
+                    if (value == null) {
                         config.error("Cannot resolve eager variable in " + sc.s.sl);
                         return false;
                     }
@@ -147,7 +147,7 @@ public class CodeBase {
         return main;
     }
 
-    
+
     public void evaluateAllExpressions()
     {
         for(SourceFile f:sources.values()) {

--- a/src/main/java/util/TextUtils.java
+++ b/src/main/java/util/TextUtils.java
@@ -1,0 +1,128 @@
+package util;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Convenience utility class with text-related utilities
+ */
+public class TextUtils {
+
+    /**
+     * Compares a string against a pattern allowing wildcards ("?", "*") in a case-sensitive manner
+     * @param pattern the pattern to check as a string
+     * @param string the string to check against the pattern
+     * @return {@code true} if the string matches the pattern
+     */
+    public static boolean matches(String pattern, String string) {
+        return matches(pattern, string, true);
+    }
+
+    /**
+     * Compares a string against a pattern allowing wildcards ("?", "*") in a case-insensitive manner
+     * @param pattern the pattern to check as a string
+     * @param string the string to check against the pattern
+     * @return {@code true} if the string matches the pattern
+     */
+    public static boolean matchesIgnoreCase(String pattern, String string) {
+        return matches(pattern, string, false);
+    }
+
+    /**
+     * Compares a string against a pattern allowing wildcards ("?", "*")
+     * @param pattern the pattern to check as a string
+     * @param string the string to check against the pattern
+     * @param caseSensitive to perform the comparison in a case-sensitive manner
+     * @return {@code true} if the string matches the pattern
+     */
+    public static boolean matches(String pPattern, String pString, boolean caseSensitive) {
+
+        // (sanity check)
+        if (StringUtils.isEmpty(pPattern)) {
+            return StringUtils.isEmpty(pString);
+        }
+
+        // (sanitizes input)
+        final String pattern = StringUtils.defaultString(pPattern);
+        final String string = StringUtils.defaultString(pString);
+
+        // Checks for every literal in proper order
+        int pos = 0;
+        for (String literal : StringUtils.splitPreserveAllTokens(pattern, '*')) {
+            final int nextPos = caseSensitive
+                    ? StringUtils.indexOf(string, literal, pos)
+                    : StringUtils.indexOfIgnoreCase(string, literal, pos);
+            if (nextPos < 0) {
+                return false;
+            }
+            pos = nextPos + literal.length();
+        }
+        return true;
+    }
+
+
+    /**
+     * Compares strings against a pattern allowing wildcards ("?", "*") in a case-sensitive manner
+     * @param pattern the pattern to check as a string
+     * @param strings the strings to check against the pattern
+     * @return {@code true} if at least one of the strings matches the pattern
+     */
+    public static boolean anyMatches(String pattern, String ... strings) {
+        return (strings != null)
+                && anyMatches(pattern, Arrays.asList(strings));
+    }
+
+    /**
+     * Compares strings against a pattern allowing wildcards ("?", "*") in a case-insensitive manner
+     * @param pattern the pattern to check as a string
+     * @param strings the strings to check against the pattern
+     * @return {@code true} if at least one of the strings matches the pattern
+     */
+    public static boolean anyMatchesIgnoreCase(String pattern, String ... strings) {
+        return (strings != null)
+                && anyMatchesIgnoreCase(pattern, Arrays.asList(strings));
+    }
+
+    /**
+     * Compares strings against a pattern allowing wildcards ("?", "*") in a case-sensitive manner
+     * @param pattern the pattern to check as a string
+     * @param strings the strings to check against the pattern
+     * @return {@code true} if at least one of the strings matches the pattern
+     */
+    public static boolean anyMatches(String pattern, Collection<String> strings) {
+        return anyMatches(pattern, strings, true);
+    }
+
+    /**
+     * Compares strings against a pattern allowing wildcards ("?", "*") in a case-insensitive manner
+     * @param pattern the pattern to check as a string
+     * @param strings the strings to check against the pattern
+     * @return {@code true} if at least one of the strings matches the pattern
+     */
+    public static boolean anyMatchesIgnoreCase(String pattern, Collection<String> strings) {
+        return anyMatches(pattern, strings, false);
+    }
+
+    private static boolean anyMatches(String pattern, Collection<String> strings, boolean caseSensitive) {
+
+        // (sanity check)
+        if (strings == null) {
+            return false;
+        }
+
+        // Checks every string for a positive match
+        for (String string: strings) {
+            if (matches(pattern, string)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    private TextUtils() {
+        super();
+    }
+}

--- a/src/test/java/test/SourceLineTrackingTest.java
+++ b/src/test/java/test/SourceLineTrackingTest.java
@@ -5,14 +5,17 @@
  */
 package test;
 
-import cl.MDLConfig;
-import cl.MDLLogger;
-import code.CodeBase;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+
 import org.junit.Assert;
 import org.junit.Test;
+
+import cl.MDLConfig;
+import cl.MDLLogger;
+import code.CodeBase;
+import util.TextUtils;
 import workers.pattopt.PatternBasedOptimizer;
 
 /**
@@ -29,47 +32,46 @@ public class SourceLineTrackingTest {
         codeBase = new CodeBase(mdlConfig);
     }
 
-    @Test public void test1() throws IOException { 
-        Assert.assertTrue(test(
-                "data/tests/test1.asm", 
-                new String[]{"INFO: Pattern-based optimization in data/tests/test1.asm#6: Replace cp 0 with or a (1 bytes, 3 t-states saved)",
-                             "INFO: Pattern-based optimization in data/tests/test1.asm#15: Remove unused ld a,0 (2 bytes, 8 t-states saved)"})); 
+    @Test public void test1() throws IOException {
+
+        // (uses wildcards to prevent test failure in Windows)
+        optimizeAndLookFor("data/tests/test1.asm",
+                "INFO: Pattern-based optimization in *test1.asm#6: Replace cp 0 with or a (1 bytes, 3 t-states saved)",
+                "INFO: Pattern-based optimization in *test1.asm#15: Remove unused ld a,0 (2 bytes, 8 t-states saved)");
     }
-    @Test public void test29() throws IOException { 
-        Assert.assertTrue(test(
-                "data/tests/test29.asm", 
-                new String[]{"INFO: Pattern-based optimization in data/tests/test29-include.asm#4 (expanded from data/tests/test29.asm#6): Replace ld a,0 with xor a (1 bytes, 3 t-states saved)",
-                             "INFO: Pattern-based optimization in data/tests/test29-include.asm#4 (expanded from data/tests/test29.asm#8): Replace ld a,0 with xor a (1 bytes, 3 t-states saved)"})); 
+    @Test public void test29() throws IOException {
+
+        // (uses wildcards to prevent test failure in Windows)
+        optimizeAndLookFor("data/tests/test29.asm",
+                "INFO: Pattern-based optimization in *test29-include.asm#4 (expanded from *test29.asm#6): Replace ld a,0 with xor a (1 bytes, 3 t-states saved)",
+                "INFO: Pattern-based optimization in *test29-include.asm#4 (expanded from *test29.asm#8): Replace ld a,0 with xor a (1 bytes, 3 t-states saved)");
     }
 
-    private boolean test(String inputFile, String expectedOutputLines[]) throws IOException
+    private void optimizeAndLookFor(String inputFile, String ... expectedOutputLines) throws IOException
     {
         Assert.assertTrue(mdlConfig.parseArgs(inputFile,"-dialect","glass"));
         Assert.assertTrue(
                 "Could not parse file " + inputFile,
                 mdlConfig.codeBaseParser.parseMainSourceFile(mdlConfig.inputFile, codeBase));
-        
-        ByteArrayOutputStream optimizerOutput = new ByteArrayOutputStream();        
-        mdlConfig.logger = new MDLLogger(MDLLogger.INFO, new PrintStream(optimizerOutput), System.err);
-        PatternBasedOptimizer po = new PatternBasedOptimizer(mdlConfig);
-        po.optimize(codeBase);
-        
-        String lines[] = optimizerOutput.toString().split("\n");
-        for(String expectedOutputLine: expectedOutputLines) {
-            boolean found = false;
-            for(String line: lines) {
-                if (line.equals(expectedOutputLine)) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                System.out.println("Expected line '"+expectedOutputLine+"' not found in actual optimizer output!");
-                return false;
-            }
+
+        // Optimizes
+        String lines[];
+        try (ByteArrayOutputStream optimizerOutput = new ByteArrayOutputStream();
+                PrintStream printStream = new PrintStream(optimizerOutput)) {
+
+            mdlConfig.logger = new MDLLogger(MDLLogger.INFO, printStream, System.err);
+            PatternBasedOptimizer po = new PatternBasedOptimizer(mdlConfig);
+            po.optimize(codeBase);
+
+            printStream.flush();
+            lines = optimizerOutput.toString().split("\n");
         }
-        
-        return true;
-    }    
-    
+
+        // Looks for expected output
+        for (String expectedOutputLine: expectedOutputLines) {
+            Assert.assertTrue(
+                    "Expected line '"+expectedOutputLine+"' not found in actual optimizer output!",
+                    TextUtils.anyMatchesIgnoreCase(expectedOutputLine, lines));
+        }
+    }
 }

--- a/src/test/java/util/TextUtilsTest.java
+++ b/src/test/java/util/TextUtilsTest.java
@@ -1,0 +1,42 @@
+package util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TextUtilsTest {
+
+	@Test
+	public void anyMatchesIgnoreCase_singleWildcard() {
+		final String[] testLines = new String[]{
+			"INFO: Pattern-based optimization in data/tests/test1.asm#6: Replace cp 0 with or a (1 bytes, 3 t-states saved)",
+			"INFO: Pattern-based optimization in data/tests/test1.asm#15: Remove unused ld a,0 (2 bytes, 8 t-states saved)",
+			"INFO: PatternBasedOptimizer: 2 patterns applied, 3 bytes, 11 t-states saved."
+		};
+
+		Assert.assertTrue(TextUtils.anyMatchesIgnoreCase(
+			"INFO: Pattern-based optimization in *test1.asm#6: Replace cp 0 with or a (1 bytes, 3 t-states saved)",
+			testLines));
+
+		Assert.assertTrue(TextUtils.anyMatchesIgnoreCase(
+			"INFO: Pattern-based optimization in *test1.asm#15: Remove unused ld a,0 (2 bytes, 8 t-states saved)",
+			testLines));
+	}
+
+	@Test
+	public void anyMatchesIgnoreCase_multipleWildcards() {
+		final String[] testLines = new String[]{
+			"INFO: Pattern-based optimization in data/tests/\\test29-include.asm#4 (expanded from data/tests/test29.asm#6): Replace ld a,0 with xor a (1 bytes, 3 t-states saved)",
+			"INFO: Pattern-based optimization in data/tests/\\test29-include.asm#4 (expanded from data/tests/test29.asm#8): Replace ld a,0 with xor a (1 bytes, 3 t-states saved)",
+			"INFO: PatternBasedOptimizer: 2 patterns applied, 2 bytes, 6 t-states saved."
+		};
+
+		Assert.assertTrue(TextUtils.anyMatchesIgnoreCase(
+			"INFO: Pattern-based optimization in *test29-include.asm#4 (expanded from *test29.asm#6): Replace ld a,0 with xor a (1 bytes, 3 t-states saved)",
+			testLines));
+
+		Assert.assertTrue(TextUtils.anyMatchesIgnoreCase(
+			"INFO: Pattern-based optimization in *test29-include.asm#4 (expanded from *test29.asm#8): Replace ld a,0 with xor a (1 bytes, 3 t-states saved)",
+			testLines));
+	}
+}


### PR DESCRIPTION
Two separate commits:
- Fixes wrong condition: there was an unboxing of Integer value where it was always null.
- Prevent test failure in Windows: different file separators causing trouble again (the output was slightly different and the test was failing)