### PR TITLE
"AND 0" is not a no-op. That's a bug. "ADD 0" is a no-op.

### DIFF
--- a/src/main/resources/data/pbo-patterns.txt
+++ b/src/main/resources/data/pbo-patterns.txt
@@ -1021,7 +1021,7 @@ pattern: Remove unnecessary ?op ?const
 replacement:
 constraints:
 equal(?const,0)
-in(?op,and,or,xor,sub)
+in(?op,add,or,xor,sub)
 flagsNotUsedAfter(0,S,Z,H,P/V,N,C)
 
 pattern: Remove unnecessary ?op a,?const


### PR DESCRIPTION
Hi @santiontanon! 

Looking at `src/main/resources/data/pbo-patterns.txt` I found something that might be a bug.
It looks like line 1024 would cause mldz80optimizer to consider `AND 0` to be a unnecessary no-op and remove it.
It is true that `OR 0`, `XOR 0` and `SUB 0` are no-op (given the assumption about flags not used), but `AND 0` can modify `A`.  `ADD 0` is a no-op, still.

This PR removes the possibly bug-introducing `AND`, replaces with the correct `ADD`, which is probably what was meant in the first place.

Incidentally, I made the table you refer to in `src/main/resources/data/*-instruction-set.tsv` files 
> ; - https://wiki.octoate.de/lib/exe/fetch.php/amstradcpc:z80_cpc_timings_cheat_sheet.20131019.pdf (for the Amstrad CPC timings)

As I wrote in that document, it's a visual layout of data from http://www.cpctech.org.uk/docs/instrtim.html made by Kevin Thacker, so you can credit him (and me if you like).
