### PR TITLE
Update integration-vscode.md: adds missing "owner": "mdl"

### DIFF
--- a/doc/integration-vscode.md
+++ b/doc/integration-vscode.md
@@ -11,35 +11,31 @@ The output of the MDL pattern-based optimizer can be integrated into VSCode usin
 		"command": "java -jar mdl.jar <main source> -po -dialect <dialect>",
 		"group": "build",
 		"problemMatcher": {
-	        "applyTo": "allDocuments",
-	        "fileLocation": [
-	          "autodetect",
-	          "${workspaceFolder}"
-	        ],
-	        "pattern": [
-	          {
-	            "regexp": "^(\\w+): (.+) in (.+)#([0-9]+): (.+)$",
-	            "file": 3,
-	            "line": 4,
-	            "severity": 1,
-	            "message": 5,
-	            "code": 2
-	          }
-	        ]
-	    },
-      	"presentation": {
-        	"echo": false,
-	        "focus": false,
-	        "panel": "shared",
-	        "showReuseMessage": false,
-	        "clear": true,
-	        "revealProblems": "onProblem"
-	    }
+			"applyTo": "allDocuments",
+			"fileLocation": [
+				"autodetect",
+				"${workspaceFolder}"
+			],
+			"owner": "mdl",
+			"pattern": [{
+				"regexp": "^(\\w+): (.+) in (.+)#([0-9]+): (.+)$",
+				"file": 3,
+				"line": 4,
+				"severity": 1,
+				"message": 5,
+				"code": 2
+			}]
+		},
+		"presentation": {
+			"echo": false,
+			"focus": false,
+			"panel": "shared",
+			"showReuseMessage": false,
+			"clear": true,
+			"revealProblems": "onProblem"
+		}
 	}]
 }
-
-
-
 ```
 
 You can, of course expand this to include other output from MDL, such as style warnings.


### PR DESCRIPTION
Fixes one of the points of the issue _VSCode integration problem_ #59:

> 1. After running the task several times in a row, the same message is displayed several times. No way to cleanup list of messages, only restart VSCode
